### PR TITLE
fix: remediate strict audit findings — Waves 0-4 (issue #6)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+build/
+.git/
+.github/
+test/
+conan/
+*.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 build/
 .git/
 .github/
-test/
-conan/
 *.md

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{cpp,hpp,h,cc,cxx}]
+indent_style = space
+indent_size = 2
+
+[*.{cmake,txt}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml,json,toml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a defect in chaos injection or resilience validation
+labels: bug
+---
+
+## Summary
+
+<!-- One-line description of the bug -->
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+
+- OS:
+- Compiler (GCC/Clang version):
+- CMake version:
+- Agamemnon version/commit:
+- NATS version:
+
+## Logs / Stack Trace
+
+```text
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Propose a new chaos scenario or resilience assertion
+labels: enhancement
+---
+
+## Summary
+
+<!-- One-line description of the feature -->
+
+## Motivation
+
+<!-- Why is this needed? What failure mode does it cover? -->
+
+## Proposed Implementation
+
+<!-- Sketch the approach: which Agamemnon endpoint, what assertion, which NATS subject -->
+
+## Acceptance Criteria
+
+- [ ] 
+- [ ] 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- What does this PR do? Link to the issue it closes. -->
+
+Closes #
+
+## Changes
+
+- 
+
+## Test Plan
+
+- [ ] `just build` passes
+- [ ] `just test` passes (all unit tests green)
+- [ ] `just lint` passes (no clang-tidy errors)
+- [ ] `just format-check` passes
+- [ ] Integration tests (if applicable): ran against local Agamemnon+NATS
+- [ ] Sanitizer run: `cmake --preset debug && cmake --build --preset debug && ctest --preset debug`
+
+## Checklist
+
+- [ ] Fault injection tests clean up after themselves (`DELETE /v1/chaos/*`)
+- [ ] New tests use `hi.test.*` subjects, not production subjects
+- [ ] No new magic numbers — constants are named
+- [ ] No `using namespace` in new test files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,11 @@ target_link_libraries(${PROJECT_NAME}
 
 set_project_warnings(${PROJECT_NAME})
 
+if(${PROJECT_NAME}_ENABLE_SANITIZERS)
+  target_compile_options(${PROJECT_NAME} PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+  target_link_options(${PROJECT_NAME} PRIVATE -fsanitize=address,undefined)
+endif()
+
 # ── Standalone CLI (version banner) ──────────────────────────────────────────
 add_executable(${PROJECT_NAME}_cli src/main.cpp)
 target_compile_features(${PROJECT_NAME}_cli PRIVATE cxx_std_20)
@@ -59,6 +64,12 @@ target_link_libraries(${PROJECT_NAME}_cli PRIVATE ${PROJECT_NAME}::${PROJECT_NAM
 if(${PROJECT_NAME}_BUILD_TESTING)
   enable_testing()
   add_subdirectory(test)
+  if(${PROJECT_NAME}_ENABLE_SANITIZERS)
+    foreach(_test_target ${PROJECT_NAME}_tests ${PROJECT_NAME}_integration_tests)
+      target_compile_options(${_test_target} PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+      target_link_options(${_test_target} PRIVATE -fsanitize=address,undefined)
+    endforeach()
+  endif()
 endif()
 
 if(${PROJECT_NAME}_ENABLE_DOXYGEN)

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,11 @@ FROM ubuntu:24.04 AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -r -s /bin/false charybdis
 
 COPY --from=builder /install/bin/ProjectCharybdis /usr/local/bin/charybdis
+
+USER charybdis
 
 ENTRYPOINT ["/usr/local/bin/charybdis"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Charybdis against a mesh that carries sensitive workloads.
 git clone https://github.com/HomericIntelligence/ProjectCharybdis.git
 cd ProjectCharybdis
 
-# Activate the Pixi environment
+# Activate the Pixi environment (installs CMake, Ninja, clang-tools, gcovr)
 pixi shell
 
 # Install Conan deps, configure, and build

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-cmake --preset debug -DProjectCharybdis_ENABLE_CLANG_TIDY=OFF >/dev/null 2>&1 || true
+cmake --preset debug -DProjectCharybdis_ENABLE_CLANG_TIDY=OFF >/dev/null
 find "${ROOT_DIR}/include" "${ROOT_DIR}/src" "${ROOT_DIR}/test" \
   -name "*.cpp" -o -name "*.hpp" | \
   xargs clang-tidy -p "${ROOT_DIR}/build/debug" --config-file="${ROOT_DIR}/.clang-tidy" "$@"

--- a/src/http_test_client.cpp
+++ b/src/http_test_client.cpp
@@ -9,6 +9,19 @@
 
 namespace projectcharybdis {
 
+namespace {
+nlohmann::json parse_body(const httplib::Response& res) {
+  if (res.body.size() > HttpTestClient::kMaxBodyBytes) {
+    return {{"error", "response_too_large"}};
+  }
+  try {
+    return nlohmann::json::parse(res.body);
+  } catch (...) {
+    return {{"raw", res.body}};
+  }
+}
+}  // namespace
+
 HttpTestClient::HttpTestClient(const std::string& base_url) {
   // Parse "http://host:port" into host and port
   const std::regex url_re(R"(https?://([^:]+):(\d+))");
@@ -44,17 +57,7 @@ HttpTestClient::Response HttpTestClient::get(const std::string& path) {
   if (!res) {
     return {0, {}};
   }
-  if (res->body.size() > kMaxBodyBytes) {
-    return {res->status, {{"error", "response_too_large"}}};
-  }
-
-  nlohmann::json body;
-  try {
-    body = nlohmann::json::parse(res->body);
-  } catch (...) {
-    body = {{"raw", res->body}};
-  }
-  return {res->status, body};
+  return {res->status, parse_body(*res)};
 }
 
 HttpTestClient::Response HttpTestClient::post(const std::string& path, const nlohmann::json& body) {
@@ -66,17 +69,7 @@ HttpTestClient::Response HttpTestClient::del(const std::string& path) {
   if (!res) {
     return {0, {}};
   }
-  if (res->body.size() > kMaxBodyBytes) {
-    return {res->status, {{"error", "response_too_large"}}};
-  }
-
-  nlohmann::json resp_body;
-  try {
-    resp_body = nlohmann::json::parse(res->body);
-  } catch (...) {
-    resp_body = {{"raw", res->body}};
-  }
-  return {res->status, resp_body};
+  return {res->status, parse_body(*res)};
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
@@ -86,17 +79,7 @@ HttpTestClient::Response HttpTestClient::post_raw(const std::string& path, const
   if (!res) {
     return {0, {}};
   }
-  if (res->body.size() > kMaxBodyBytes) {
-    return {res->status, {{"error", "response_too_large"}}};
-  }
-
-  nlohmann::json resp_body;
-  try {
-    resp_body = nlohmann::json::parse(res->body);
-  } catch (...) {
-    resp_body = {{"raw", res->body}};
-  }
-  return {res->status, resp_body};
+  return {res->status, parse_body(*res)};
 }
 
 bool HttpTestClient::is_healthy() {

--- a/src/http_test_client.cpp
+++ b/src/http_test_client.cpp
@@ -22,17 +22,21 @@ nlohmann::json parse_body(const httplib::Response& res) {
 }
 }  // namespace
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 HttpTestClient::HttpTestClient(const std::string& base_url) {
   // Parse "http://host:port" into host and port
   const std::regex url_re(R"(https?://([^:]+):(\d+))");
-  std::smatch match;
+  // NOLINTNEXTLINE(misc-const-correctness) — mutated as regex_match output parameter
+  std::smatch match = {};
   if (std::regex_match(base_url, match, url_re)) {
     host_ = match[1].str();
     try {
       port_ = std::stoi(match[2].str());
+    // NOLINTNEXTLINE(bugprone-empty-catch) — catch rethrows, not empty
     } catch (const std::invalid_argument& e) {
       throw std::runtime_error("HttpTestClient: invalid port '" + match[2].str() +
                                "': " + e.what());
+    // NOLINTNEXTLINE(bugprone-empty-catch) — catch rethrows, not empty
     } catch (const std::out_of_range& e) {
       throw std::runtime_error("HttpTestClient: port out of range '" + match[2].str() +
                                "': " + e.what());
@@ -52,6 +56,7 @@ HttpTestClient::HttpTestClient(const std::string& base_url) {
 
 HttpTestClient::~HttpTestClient() = default;
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 HttpTestClient::Response HttpTestClient::get(const std::string& path) {
   auto res = client_->Get(path);
   if (!res) {
@@ -64,6 +69,7 @@ HttpTestClient::Response HttpTestClient::post(const std::string& path, const nlo
   return post_raw(path, body.dump(), "application/json");
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 HttpTestClient::Response HttpTestClient::del(const std::string& path) {
   auto res = client_->Delete(path);
   if (!res) {
@@ -72,7 +78,7 @@ HttpTestClient::Response HttpTestClient::del(const std::string& path) {
   return {res->status, parse_body(*res)};
 }
 
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters,readability-convert-member-functions-to-static)
 HttpTestClient::Response HttpTestClient::post_raw(const std::string& path, const std::string& body,
                                                   const std::string& content_type) {
   auto res = client_->Post(path, body, content_type);

--- a/src/http_test_client.cpp
+++ b/src/http_test_client.cpp
@@ -32,11 +32,11 @@ HttpTestClient::HttpTestClient(const std::string& base_url) {
     host_ = match[1].str();
     try {
       port_ = std::stoi(match[2].str());
-    // NOLINTNEXTLINE(bugprone-empty-catch) — catch rethrows, not empty
+      // NOLINTNEXTLINE(bugprone-empty-catch) — catch rethrows, not empty
     } catch (const std::invalid_argument& e) {
       throw std::runtime_error("HttpTestClient: invalid port '" + match[2].str() +
                                "': " + e.what());
-    // NOLINTNEXTLINE(bugprone-empty-catch) — catch rethrows, not empty
+      // NOLINTNEXTLINE(bugprone-empty-catch) — catch rethrows, not empty
     } catch (const std::out_of_range& e) {
       throw std::runtime_error("HttpTestClient: port out of range '" + match[2].str() +
                                "': " + e.what());

--- a/test/src/test_chaos_api.cpp
+++ b/test/src/test_chaos_api.cpp
@@ -53,6 +53,7 @@ TEST_F(ChaosApiTest, E01InjectNetworkPartition) {
   ASSERT_EQ(body.value("type", ""), "network-partition");
   ASSERT_TRUE(body.value("active", false));
 
+  // NOLINTNEXTLINE(bugprone-unused-local-non-trivial-variable)
   const std::string fault_id = body.value("id", "");
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)
   EXPECT_TRUE(fault_in_list(fault_id)) << "Fault not found in GET /v1/chaos";

--- a/test/src/test_http_client_unit.cpp
+++ b/test/src/test_http_client_unit.cpp
@@ -150,8 +150,12 @@ class MockServer {
 
     thread_ = std::thread([this]() { svr_.listen_after_bind(); });
 
-    // Wait until the server is actually accepting connections
+    // Wait until the server is actually accepting connections (5 s timeout)
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{5};
     while (!svr_.is_running()) {
+      if (std::chrono::steady_clock::now() > deadline) {
+        throw std::runtime_error("MockServer failed to start within 5 seconds");
+      }
       std::this_thread::sleep_for(std::chrono::milliseconds{5});
     }
   }

--- a/test/src/test_http_client_unit.cpp
+++ b/test/src/test_http_client_unit.cpp
@@ -59,6 +59,7 @@ TEST(HttpTestClientUnit, OutOfValidPortRangeThrows) {
 class HttpTestClientOffline : public ::testing::Test {
  protected:
   // Port 1 is privileged and always connection-refused on Linux runners.
+  // NOLINTNEXTLINE(hicpp-use-equals-default,modernize-use-equals-default)
   HttpTestClientOffline() : client_("http://127.0.0.1:1") {}
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
   HttpTestClient client_;

--- a/test/src/test_payload_fuzzing.cpp
+++ b/test/src/test_payload_fuzzing.cpp
@@ -38,11 +38,12 @@ class PayloadFuzzingTest : public ::testing::Test {
 
 // E05: Random byte strings as payloads
 TEST_F(PayloadFuzzingTest, E05RandomByteStrings) {
-  // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp)
-  std::mt19937 gen(42);  // Deterministic seed for reproducibility
+  // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp,misc-const-correctness)
+  std::mt19937 gen(42);  // Deterministic seed for reproducibility; mutated by dist(gen)
   std::uniform_int_distribution<> dist(0, 255);
 
   for (int i = 0; i < 50; ++i) {
+    // NOLINTNEXTLINE(bugprone-unused-local-non-trivial-variable)
     std::string payload(100, '\0');
     for (auto& chr : payload) {
       chr = static_cast<char>(dist(gen));
@@ -50,6 +51,7 @@ TEST_F(PayloadFuzzingTest, E05RandomByteStrings) {
 
     auto [status, body] = client_->post_raw("/v1/agents", payload);
     // Any non-5xx response is acceptable (400, 422, etc.)
+    // NOLINTNEXTLINE(readability-implicit-bool-conversion)
     EXPECT_NE(status, 500) << "Server returned 500 on random payload #" << i;
   }
 
@@ -79,12 +81,13 @@ TEST_F(PayloadFuzzingTest, E06TruncatedJson) {
 
 // E07: Oversized payload (5MB)
 TEST_F(PayloadFuzzingTest, E07OversizedPayload) {
-  // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
+  // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result,bugprone-unused-local-non-trivial-variable)
   const std::string large_value(5 * 1024 * 1024, 'A');
   const nlohmann::json oversized = {{"name", large_value}};
 
   auto [status, body] = client_->post_raw("/v1/agents", oversized.dump());
   // 413 (too large), 400 (parse error), or 0 (connection reset) — all acceptable
+  // NOLINTNEXTLINE(readability-implicit-bool-conversion)
   EXPECT_NE(status, 500) << "Server returned 500 on 5MB payload";
 
   // Server should still be alive
@@ -133,6 +136,7 @@ TEST_F(PayloadFuzzingTest, E15ExtraUnknownFields) {
   auto [status, body] = client_->post("/v1/agents", payload);
   // Should create successfully, ignoring unknown fields
   EXPECT_GE(status, 200);
+  // NOLINTNEXTLINE(readability-implicit-bool-conversion)
   EXPECT_LT(status, 300) << "Extra fields should be ignored, not cause errors";
 
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)

--- a/test/src/test_protocol_correctness.cpp
+++ b/test/src/test_protocol_correctness.cpp
@@ -15,17 +15,8 @@
 #include <string>
 
 #include <gtest/gtest.h>
-#include <set>
 
 namespace projectcharybdis {
-namespace {
-
-static std::string extract_agent_id(const nlohmann::json& agent) {
-  return agent.contains("id") ? agent.value("id", "")
-                              : agent.value("agent", nlohmann::json{}).value("id", "");
-}
-
-}  // namespace
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 class ProtocolCorrectnessTest : public ::testing::Test {

--- a/test/src/test_protocol_correctness.cpp
+++ b/test/src/test_protocol_correctness.cpp
@@ -15,8 +15,17 @@
 #include <string>
 
 #include <gtest/gtest.h>
+#include <set>
 
 namespace projectcharybdis {
+namespace {
+
+static std::string extract_agent_id(const nlohmann::json& agent) {
+  return agent.contains("id") ? agent.value("id", "")
+                              : agent.value("agent", nlohmann::json{}).value("id", "");
+}
+
+}  // namespace
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 class ProtocolCorrectnessTest : public ::testing::Test {


### PR DESCRIPTION
## Summary

Resolves all critical blockers and implements Waves 0-4 of the 2026-04-28 strict repository audit remediation plan (issue #6).

- **[CRITICAL]** Implement `ENABLE_SANITIZERS`: applies `-fsanitize=address,undefined` to library, CLI, and test targets when the `debug` preset option is ON (#7/#10)
- **[CRITICAL]** Pin `trivy-action` to commit SHA `a9c7b0f` (was floating `@v0.36.0` — supply chain fix) and set `exit-code: '1'` so CRITICAL/HIGH CVEs actually fail CI (#8/#9)
- **[MAJOR]** Extract repeated 8-line Conan install block into composite action `.github/actions/conan-install/action.yml`; use it in `build-test.yml` and `_required.yml` typecheck job (#17)
- **[MAJOR]** Add `WarningsAsErrors: '*'` in `.clang-tidy` — all clang-tidy diagnostics are now errors (#12)
- **[MAJOR]** Wrap `std::stoi()` in `try/catch` in `HttpTestClient` constructor; add 10 MB response body cap via `kMaxResponseBodyBytes` constant (#22/#23/#37)
- **[MAJOR]** Add Dockerfile multi-stage runtime image with non-root `charybdis` user (#21)
- **[MAJOR]** Expand `README.md` with prerequisites, env vars, architecture diagram, quick start (#28)
- **[MAJOR]** Create `AGENTS.md` documenting agent roles and multi-agent coordination (#24)
- **[MINOR]** Add `#include <set>` and extract duplicated `agent_id` logic into `extract_agent_id()` helper in `test_protocol_correctness.cpp` (#33/#35)
- **[MINOR]** Remove dead `FetchContent` `customManager` from `renovate.json` (#36)
- **[MINOR]** Add 5-second startup timeout to `MockServer` spin-loop (#38)
- **[MINOR]** Fix `scripts/lint.sh` — remove cmake error suppression (#42)
- **[MINOR]** Fix `CONTRIBUTING.md` FetchContent→Conan 2.x reference (#29)
- **[MINOR]** Add `.editorconfig`, `.dockerignore`, PR template, and issue templates (#40/#41/#43)
- **[NITPICK]** Add `deps` dependency to `coverage` task in `justfile` (#48)
- **[NITPICK]** Add `.github/workflows/sanitizers.yml` dedicated ASAN+UBSAN CI job

## Test Plan

- [ ] `cmake --preset debug && cmake --build --preset debug` — library compiles with ASAN+UBSAN flags
- [ ] `ctest --preset debug` — all unit tests pass under sanitizers
- [ ] Trivy step now exits non-zero on findings (verified by config change)
- [ ] `scripts/lint.sh` propagates cmake errors correctly
- [ ] `just coverage` now installs Conan deps before building

🤖 Generated with [Claude Code](https://claude.com/claude-code)