### PR TITLE
fix(ci): pin all GitHub Actions to immutable SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -115,9 +115,9 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event_name != 'workflow_run'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event_name != 'workflow_run'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
       - name: Detect secrets
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event_name != 'workflow_run'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Install check-jsonschema
         run: pip3 install --user check-jsonschema
       - name: Validate workflow schemas
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event_name != 'workflow_run'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Parse VERSION from CMakeLists.txt
         run: |
           VERSION=$(grep -A5 'project(' CMakeLists.txt \
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event_name != 'workflow_run'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
         compiler: [gcc, clang]
         build_type: [debug, release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Install dependencies
         env:
           COMPILER: ${{ matrix.compiler }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -11,7 +11,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     name: clang-format
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Install clang-format
         run: sudo apt-get install -y clang-format
       - name: Check formatting
@@ -21,7 +21,7 @@ jobs:
     name: clang-tidy
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Install dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary

- Pin `aquasecurity/trivy-action@v0.36.0` to immutable commit SHA `ed142fd0673e97e23eac54620cfb913e5ce36c25` (annotated tag dereferenced)
- Pin `actions/checkout@v4` to `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1) across all four workflow files
- Add `.github/dependabot.yml` with `github-actions` ecosystem on weekly schedule so Dependabot keeps pinned SHAs current

Floating branch/tag references (`@master`, `@v4`, mutable version tags) allow upstream code changes to execute silently on every PR — a supply chain attack vector. Immutable SHA pins eliminate this risk entirely.

## Test plan

- [ ] Verify all `uses:` lines now reference 40-char SHAs with human-readable `# vX.Y.Z` comments
- [ ] Confirm Dependabot config is valid (`version: 2`, `github-actions` ecosystem)
- [ ] CI workflows pass (no functional changes — only pin format changed)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)