### PR TITLE
fix(ci): enforce Trivy exit-code 1 to block on CRITICAL/HIGH vulns

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -121,7 +121,8 @@ jobs:
         with:
           scan-type: fs
           scan-ref: .
-          exit-code: '0'
+          exit-code: '1'
+          ignore-unfixed: true
           severity: CRITICAL,HIGH
       - name: Install Conan (for audit)
         run: pip3 install --user conan


### PR DESCRIPTION
## Summary

- Changes Trivy `exit-code` from `'0'` to `'1'` so CRITICAL/HIGH severity vulnerabilities with available fixes fail CI and block merges
- Adds `ignore-unfixed: true` to suppress CVEs with no upstream patch, keeping the signal actionable and avoiding false blocks on unremediated CVEs
- No other steps in the workflow are affected

## Why

With `exit-code: '0'`, the security scan was purely informational — a vulnerable dependency could be merged and shipped without any CI block. This is security theater as described in issue #9 (POLA violation: the scan appearing to gate merges but not actually doing so).

## Test plan

- [ ] CI passes on this branch (no current CRITICAL/HIGH fixable CVEs in the repo)
- [ ] Confirm `security/dependency-scan` job shows as enforcing (exit 1 on findings) in CI run

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)