### PR TITLE
refactor(http_test_client): persist httplib::Client, add timeout constants

### DIFF
--- a/include/projectcharybdis/http_test_client.hpp
+++ b/include/projectcharybdis/http_test_client.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
+
+namespace httplib {
+class Client;
+}  // namespace httplib
 
 namespace projectcharybdis {
 
@@ -12,6 +17,7 @@ class HttpTestClient {
   static constexpr std::size_t kMaxBodyBytes = 10 * 1024 * 1024;  // 10 MB
 
   explicit HttpTestClient(const std::string& base_url = "http://localhost:8080");
+  ~HttpTestClient();
 
   /// GET request, returns {status_code, body_json}
   struct Response {
@@ -30,8 +36,12 @@ class HttpTestClient {
   bool is_healthy();
 
  private:
+  static constexpr int kConnectionTimeoutSec = 5;
+  static constexpr int kReadTimeoutSec = 10;
+
   std::string host_;
   int port_;
+  std::unique_ptr<httplib::Client> client_;
 };
 
 }  // namespace projectcharybdis

--- a/src/http_test_client.cpp
+++ b/src/http_test_client.cpp
@@ -31,14 +31,15 @@ HttpTestClient::HttpTestClient(const std::string& base_url) {
     host_ = "localhost";
     port_ = 8080;
   }
+  client_ = std::make_unique<httplib::Client>(host_, port_);
+  client_->set_connection_timeout(kConnectionTimeoutSec);
+  client_->set_read_timeout(kReadTimeoutSec);
 }
 
-HttpTestClient::Response HttpTestClient::get(const std::string& path) {
-  httplib::Client cli(host_, port_);
-  cli.set_connection_timeout(5);
-  cli.set_read_timeout(10);
+HttpTestClient::~HttpTestClient() = default;
 
-  auto res = cli.Get(path);
+HttpTestClient::Response HttpTestClient::get(const std::string& path) {
+  auto res = client_->Get(path);
   if (!res) return {0, {}};
   if (res->body.size() > kMaxBodyBytes) return {res->status, {{"error", "response_too_large"}}};
 
@@ -56,11 +57,7 @@ HttpTestClient::Response HttpTestClient::post(const std::string& path, const nlo
 }
 
 HttpTestClient::Response HttpTestClient::del(const std::string& path) {
-  httplib::Client cli(host_, port_);
-  cli.set_connection_timeout(5);
-  cli.set_read_timeout(10);
-
-  auto res = cli.Delete(path);
+  auto res = client_->Delete(path);
   if (!res) return {0, {}};
   if (res->body.size() > kMaxBodyBytes) return {res->status, {{"error", "response_too_large"}}};
 
@@ -75,11 +72,7 @@ HttpTestClient::Response HttpTestClient::del(const std::string& path) {
 
 HttpTestClient::Response HttpTestClient::post_raw(const std::string& path, const std::string& body,
                                                   const std::string& content_type) {
-  httplib::Client cli(host_, port_);
-  cli.set_connection_timeout(5);
-  cli.set_read_timeout(10);
-
-  auto res = cli.Post(path, body, content_type);
+  auto res = client_->Post(path, body, content_type);
   if (!res) return {0, {}};
   if (res->body.size() > kMaxBodyBytes) return {res->status, {{"error", "response_too_large"}}};
 


### PR DESCRIPTION
## Summary

- Replace three identical per-request `httplib::Client` construction + timeout blocks in `get()`, `del()`, and `post_raw()` with a single persistent `std::unique_ptr<httplib::Client>` member initialized once in the constructor
- Add `static constexpr int kConnectionTimeoutSec = 5` and `kReadTimeoutSec = 10` to replace the magic numbers
- Forward-declare `httplib::Client` in the header to avoid pulling `httplib.h` into consumers; add `~HttpTestClient()` to ensure `unique_ptr` destructs with the complete type available in the `.cpp`

## Test plan

- [x] `cmake --build --preset debug` — zero errors
- [x] `ctest --preset debug` — 24/24 unit tests pass; 14 integration tests skipped (require live NATS/Agamemnon)
- [x] All `HttpTestClientOnline`, `HttpTestClientOffline`, and `HttpTestClientUnit` test cases pass

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)