### PR TITLE
ci(integration): run integration tests in CI with NATS + mock Agamemnon

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -2,7 +2,7 @@ name: Required Checks
 
 on:
   workflow_run:
-    workflows: ["Build and Test", "Static Analysis", "Code Coverage", "CodeQL SAST", "Sanitizers", "Lock Check", "Container Build and Publish"]
+    workflows: ["Build and Test", "Static Analysis", "Code Coverage", "CodeQL SAST", "Sanitizers", "Lock Check", "Container Build and Publish", "Integration Tests"]
     types: [completed]
   pull_request:
     branches: [main]
@@ -67,21 +67,21 @@ jobs:
     runs-on: ubuntu-24.04
     if: >
       github.event_name != 'workflow_run' ||
-      github.event.workflow.name == 'Build and Test'
+      github.event.workflow.name == 'Integration Tests'
     steps:
-      - name: Check Build and Test result
+      - name: Check Integration Tests result
         if: github.event_name == 'workflow_run'
         env:
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
           if [ "${CONCLUSION}" != "success" ]; then
-            echo "Build and Test workflow failed with: ${CONCLUSION}"
+            echo "Integration Tests workflow failed with: ${CONCLUSION}"
             exit 1
           fi
-          echo "Build and Test passed"
+          echo "Integration Tests passed"
       - name: Skip (not triggered by this workflow)
         if: github.event_name != 'workflow_run'
-        run: echo "Not a workflow_run event — pass (actual work done by Build and Test workflow)"
+        run: echo "Not a workflow_run event — pass (actual work done by Integration Tests workflow)"
 
   lint:
     name: lint

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,71 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  integration:
+    name: integration-tests
+    runs-on: ubuntu-24.04
+
+    services:
+      nats:
+        image: nats:latest
+        ports:
+          - 4222:4222
+        # nats:latest is a scratch image — no shell, so no healthcheck.
+        # Tests use wait_until() to retry connections instead.
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build python3 python3-pip
+          pip3 install --user conan
+
+      - name: Configure Conan
+        run: conan profile detect --force
+
+      - name: Install Conan dependencies (gcc/release)
+        run: |
+          conan install . \
+            --output-folder=build/ci \
+            --build=missing \
+            -s build_type=Release \
+            -s compiler=gcc \
+            -s compiler.version=14 \
+            -s compiler.libcxx=libstdc++11 \
+            -s compiler.cppstd=20
+
+      - name: Configure
+        run: cmake --preset ci
+
+      - name: Build
+        run: cmake --build --preset ci
+
+      - name: Start mock Agamemnon
+        run: python3 scripts/mock-agamemnon.py 8080 &
+        # Give the mock a moment to bind before tests connect
+        env:
+          PYTHONUNBUFFERED: "1"
+
+      - name: Wait for mock Agamemnon to be ready
+        run: |
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8080/v1/health | grep -q '"ok"'; then
+              echo "mock-agamemnon ready"; exit 0
+            fi
+            sleep 0.5
+          done
+          echo "mock-agamemnon did not become ready in time"; exit 1
+
+      - name: Run integration tests
+        env:
+          AGAMEMNON_URL: http://localhost:8080
+          NATS_URL: nats://localhost:4222
+        run: ctest --preset integration

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -102,6 +102,16 @@
     },
     {"name": "release", "configurePreset": "release", "output": {"outputOnFailure": true}},
     {"name": "coverage", "configurePreset": "coverage", "output": {"outputOnFailure": true}},
-    {"name": "ci", "configurePreset": "ci", "output": {"outputOnFailure": true}}
+    {"name": "ci", "configurePreset": "ci", "output": {"outputOnFailure": true}},
+    {
+      "name": "integration",
+      "configurePreset": "ci",
+      "output": {"outputOnFailure": true},
+      "filter": {
+        "include": {
+          "label": "REQUIRES_NATS"
+        }
+      }
+    }
   ]
 }

--- a/scripts/mock-agamemnon.py
+++ b/scripts/mock-agamemnon.py
@@ -5,16 +5,21 @@ Minimal Agamemnon stub for integration tests in CI.
 Implements just enough of the Agamemnon REST API so that the chaos/resilience
 integration tests pass without a live HomericIntelligence mesh:
 
-  GET  /v1/health                  → {"status":"ok"}
+  GET  /v1/health                  → {"status":"ok"}, or 503 if a 'kill' fault is active
   POST /v1/chaos/<type>            → creates a fault record
   GET  /v1/chaos                   → lists active faults
   DEL  /v1/chaos/<id>              → removes a fault
   POST /v1/teams                   → creates a team record
   POST /v1/agents                  → creates an agent record
   POST /v1/teams/<id>/tasks        → creates a task (pending)
-  GET  /v1/tasks                   → lists tasks (immediately marks them completed)
+  GET  /v1/tasks                   → lists tasks; marks completed only when no queue-starve active
   POST /v1/chaos/test-empty        → accepts any body, returns 400 on empty JSON
   POST /v1/agents (malformed)      → returns 400 on bad content-type or unparseable body
+
+Chaos effects simulated:
+  - latency: injects time.sleep(delay_ms/1000) before every response
+  - kill:    /v1/health returns 503 {"status":"degraded"}
+  - queue-starve: GET /v1/tasks does NOT advance tasks to 'completed'
 
 All state is in-process (no persistence); the stub is single-threaded but
 that is fine for the sequential test suite.
@@ -32,6 +37,30 @@ _faults: dict = {}
 _teams: dict = {}
 _agents: dict = {}
 _tasks: dict = {}
+
+
+def _active_latency_ms() -> int:
+    """Return the sum of delay_ms across all active latency faults (0 if none)."""
+    total = 0
+    for f in _faults.values():
+        if f.get("type") == "latency" and f.get("active", False):
+            total += int(f.get("delay_ms", 0))
+    return total
+
+
+def _kill_active() -> bool:
+    """Return True if any kill fault is currently active."""
+    return any(
+        f.get("type") == "kill" and f.get("active", False) for f in _faults.values()
+    )
+
+
+def _queue_starve_active() -> bool:
+    """Return True if any queue-starve fault is currently active."""
+    return any(
+        f.get("type") == "queue-starve" and f.get("active", False)
+        for f in _faults.values()
+    )
 
 CHAOS_TYPES = {"network-partition", "latency", "kill", "queue-starve", "test-empty"}
 
@@ -53,6 +82,10 @@ class AgamemnonHandler(BaseHTTPRequestHandler):
         pass
 
     def _send(self, status: int, body: dict) -> None:
+        # Simulate latency fault: sleep before sending any response.
+        delay = _active_latency_ms()
+        if delay > 0:
+            time.sleep(delay / 1000.0)
         payload = json.dumps(body).encode()
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
@@ -64,15 +97,21 @@ class AgamemnonHandler(BaseHTTPRequestHandler):
         path = urlparse(self.path).path.rstrip("/")
 
         if path == "/v1/health":
-            self._send(200, {"status": "ok"})
+            # Simulate kill fault: return 503 degraded while kill is active.
+            if _kill_active():
+                self._send(503, {"status": "degraded"})
+            else:
+                self._send(200, {"status": "ok"})
 
         elif path == "/v1/chaos":
             self._send(200, {"faults": list(_faults.values())})
 
         elif path == "/v1/tasks":
-            # Immediately mark every pending task as completed so polling tests terminate.
-            for task in _tasks.values():
-                task["status"] = "completed"
+            # Mark pending tasks as completed only when no queue-starve fault is active.
+            # During a queue-starve, tasks remain pending so the test can observe the effect.
+            if not _queue_starve_active():
+                for task in _tasks.values():
+                    task["status"] = "completed"
             self._send(200, {"tasks": list(_tasks.values())})
 
         else:

--- a/scripts/mock-agamemnon.py
+++ b/scripts/mock-agamemnon.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Minimal Agamemnon stub for integration tests in CI.
+
+Implements just enough of the Agamemnon REST API so that the chaos/resilience
+integration tests pass without a live HomericIntelligence mesh:
+
+  GET  /v1/health                  → {"status":"ok"}
+  POST /v1/chaos/<type>            → creates a fault record
+  GET  /v1/chaos                   → lists active faults
+  DEL  /v1/chaos/<id>              → removes a fault
+  POST /v1/teams                   → creates a team record
+  POST /v1/agents                  → creates an agent record
+  POST /v1/teams/<id>/tasks        → creates a task (pending)
+  GET  /v1/tasks                   → lists tasks (immediately marks them completed)
+  POST /v1/chaos/test-empty        → accepts any body, returns 400 on empty JSON
+  POST /v1/agents (malformed)      → returns 400 on bad content-type or unparseable body
+
+All state is in-process (no persistence); the stub is single-threaded but
+that is fine for the sequential test suite.
+"""
+
+import json
+import uuid
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Optional
+from urllib.parse import urlparse
+
+_faults: dict = {}
+_teams: dict = {}
+_agents: dict = {}
+_tasks: dict = {}
+
+CHAOS_TYPES = {"network-partition", "latency", "kill", "queue-starve", "test-empty"}
+
+
+def _parse_body(handler: "AgamemnonHandler") -> "tuple[Optional[dict], bool]":
+    """Return (parsed_json_or_None, body_was_empty)."""
+    length = int(handler.headers.get("Content-Length", 0))
+    raw = handler.rfile.read(length) if length else b""
+    if not raw:
+        return None, True
+    try:
+        return json.loads(raw), False
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None, False
+
+
+class AgamemnonHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt: str, *args: object) -> None:  # silence access log
+        pass
+
+    def _send(self, status: int, body: dict) -> None:
+        payload = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path.rstrip("/")
+
+        if path == "/v1/health":
+            self._send(200, {"status": "ok"})
+
+        elif path == "/v1/chaos":
+            self._send(200, {"faults": list(_faults.values())})
+
+        elif path == "/v1/tasks":
+            # Immediately mark every pending task as completed so polling tests terminate.
+            for task in _tasks.values():
+                task["status"] = "completed"
+            self._send(200, {"tasks": list(_tasks.values())})
+
+        else:
+            self._send(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        path = urlparse(self.path).path.rstrip("/")
+        ct = self.headers.get("Content-Type", "")
+        body, empty = _parse_body(self)
+
+        # /v1/chaos/<type>
+        if path.startswith("/v1/chaos/"):
+            chaos_type = path[len("/v1/chaos/"):]
+            if chaos_type not in CHAOS_TYPES:
+                self._send(404, {"error": "unknown chaos type"})
+                return
+            if empty:
+                # test-empty and other endpoints: empty body → 400
+                self._send(400, {"error": "empty body"})
+                return
+            fault_id = str(uuid.uuid4())
+            fault = {"id": fault_id, "type": chaos_type, "active": True}
+            if body:
+                fault.update({k: v for k, v in body.items() if k not in fault})
+            _faults[fault_id] = fault
+            self._send(201, fault)
+            return
+
+        # /v1/teams
+        if path == "/v1/teams":
+            if not _is_json(ct) or body is None:
+                self._send(400, {"error": "bad request"})
+                return
+            team_id = str(uuid.uuid4())
+            team = {"id": team_id, "name": body.get("name", "unnamed")}
+            _teams[team_id] = team
+            self._send(201, {"team": team})
+            return
+
+        # /v1/teams/<id>/tasks
+        if path.startswith("/v1/teams/") and path.endswith("/tasks"):
+            parts = path.split("/")
+            if len(parts) >= 4:
+                team_id = parts[3]
+            else:
+                team_id = "unknown"
+            if not _is_json(ct) or body is None:
+                self._send(400, {"error": "bad request"})
+                return
+            task_id = str(uuid.uuid4())
+            task = {
+                "id": task_id,
+                "team_id": team_id,
+                "subject": body.get("subject", ""),
+                "status": "pending",
+            }
+            _tasks[task_id] = task
+            self._send(201, {"task": task})
+            return
+
+        # /v1/agents
+        if path == "/v1/agents":
+            if not _is_json(ct) or body is None:
+                self._send(400, {"error": "bad request"})
+                return
+            agent_id = str(uuid.uuid4())
+            agent = {"id": agent_id, "name": body.get("name", "unnamed")}
+            _agents[agent_id] = agent
+            self._send(201, {"agent": agent, "id": agent_id})
+            return
+
+        self._send(404, {"error": "not found"})
+
+    def do_DELETE(self) -> None:
+        path = urlparse(self.path).path.rstrip("/")
+
+        if path.startswith("/v1/chaos/"):
+            fault_id = path[len("/v1/chaos/"):]
+            if fault_id in _faults:
+                del _faults[fault_id]
+                self._send(200, {"deleted": fault_id})
+            else:
+                self._send(404, {"error": "fault not found"})
+            return
+
+        self._send(404, {"error": "not found"})
+
+
+def _is_json(content_type: str) -> bool:
+    return "application/json" in content_type or content_type == ""
+
+
+def main() -> None:
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    server = HTTPServer(("0.0.0.0", port), AgamemnonHandler)
+    print(f"mock-agamemnon listening on :{port}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **CMakePresets.json**: adds an `integration` testPreset that filters by `REQUIRES_NATS` label so `ctest --preset integration` runs only integration tests — not unit tests.
- **scripts/mock-agamemnon.py**: a stdlib-only Python HTTP stub that implements the Agamemnon REST surface used by the test suite (`/v1/health`, `/v1/chaos/*`, `/v1/teams`, `/v1/agents`, `/v1/tasks`). No pip dependencies.
- **.github/workflows/integration-tests.yml**: new standalone workflow — spins up `nats:latest` service container (no healthcheck; scratch image has no shell), starts the mock Agamemnon as a background step, builds with `--preset ci`, and runs `ctest --preset integration`.
- **.github/workflows/_required.yml**: adds `Integration Tests` to the `workflow_run` trigger and repoints the `integration-tests` fan-in job to check that workflow's conclusion, making it a required check for merging.

## Root cause

`test/CMakeLists.txt:42` labels integration tests `REQUIRES_NATS` but the old `_required.yml` `integration-tests` job was a clone of the `build`/`unit-tests` fan-in jobs — it only reflected whether `Build and Test` succeeded, never actually running the integration suite. All four integration test fixtures call `GTEST_SKIP()` when `is_healthy()` returns false, so they silently passed in CI with zero real coverage.

## Test plan

- [ ] Open PR → confirm `Integration Tests` workflow appears in Checks
- [ ] Confirm tests show `PASSED`/`FAILED` (not `SKIPPED`) in workflow log
- [ ] Confirm `_required.yml` blocks merge if `integration-tests` job fails
- [ ] `ctest --preset integration -N` (dry-run) should list only the 4 integration test targets, not unit tests

Closes #13
Part of #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)