### PR TITLE
chore(governance): require 1 approving review before merge on main

### DIFF
--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Idempotent: sets required_approving_review_count=1 on the homeric-main-baseline ruleset.
+# Preserves all other rules (deletion, required_signatures, required_status_checks).
+# Requires: gh auth login with a token holding repo scope and admin rights.
+set -euo pipefail
+
+ORG="HomericIntelligence"
+REPO="ProjectCharybdis"
+RULESET_NAME="homeric-main-baseline"
+
+RULESET_ID=$(gh api "repos/${ORG}/${REPO}/rulesets" \
+  --jq ".[] | select(.name == \"${RULESET_NAME}\") | .id")
+
+if [ -z "${RULESET_ID}" ]; then
+  echo "ERROR: ruleset '${RULESET_NAME}' not found — create it first." >&2
+  exit 1
+fi
+
+echo "Found ruleset '${RULESET_NAME}' (id=${RULESET_ID})"
+
+# Build the PUT payload: take current ruleset, patch pull_request rule in-place.
+PAYLOAD=$(gh api "repos/${ORG}/${REPO}/rulesets/${RULESET_ID}" | jq '
+  .rules |= map(
+    if .type == "pull_request"
+    then .parameters.required_approving_review_count = 1
+    else .
+    end
+  )
+  | {name, target, enforcement, conditions, rules, bypass_actors}
+')
+
+gh api -X PUT "repos/${ORG}/${REPO}/rulesets/${RULESET_ID}" \
+  --input <(echo "${PAYLOAD}") \
+  --silent
+
+# Verify
+COUNT=$(gh api "repos/${ORG}/${REPO}/rulesets/${RULESET_ID}" \
+  --jq '.rules[] | select(.type == "pull_request") | .parameters.required_approving_review_count')
+
+if [ "${COUNT}" != "1" ]; then
+  echo "FAIL: required_approving_review_count is '${COUNT}', expected 1" >&2
+  exit 1
+fi
+
+echo "OK: required_approving_review_count=1 confirmed on '${RULESET_NAME}'"


### PR DESCRIPTION
## Summary

- Adds `scripts/apply-branch-protection.sh` — an idempotent script that patches the `homeric-main-baseline` GitHub ruleset to set `required_approving_review_count: 1`
- The script has already been run; the change is **live**: PRs to `main` now require at least one peer approval before merge
- All existing rules (deletion, required_signatures, required_status_checks) are preserved — only the pull_request rule's count is patched

Closes #15

## Test plan

- [x] Script executed successfully against live ruleset (id=15556497)
- [x] Verified via API: `required_approving_review_count` is now `1`
- [x] All other ruleset rules (deletion, required_signatures, 9 required status checks) remain intact
- [x] Script is idempotent: re-running produces the same result without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)