### PR TITLE
fix(deps): commit conan.lock for reproducible builds

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -206,6 +206,7 @@ jobs:
         run: |
           CC=clang CXX=clang++ conan install . \
             --output-folder=build/debug \
+            --lockfile=conan.lock \
             --build=missing \
             -s build_type=Debug \
             -s compiler=clang \
@@ -216,3 +217,31 @@ jobs:
         run: CC=clang CXX=clang++ cmake --preset debug -DProjectCharybdis_ENABLE_CLANG_TIDY=ON
       - name: Build (clang-tidy runs as part of build)
         run: cmake --build --preset debug
+
+  lockfile-integrity:
+    name: lockfile-integrity
+    runs-on: ubuntu-24.04
+    if: github.event_name != 'workflow_run'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Conan
+        run: pip3 install --user conan
+      - name: Configure Conan profile
+        run: conan profile detect --force
+      - name: Regenerate lockfile
+        run: |
+          conan lock create . \
+            -s compiler=gcc \
+            -s compiler.version=14 \
+            -s compiler.libcxx=libstdc++11 \
+            -s compiler.cppstd=20 \
+            -s build_type=Debug \
+            -s os=Linux \
+            -s arch=x86_64
+      - name: Verify lockfile is up-to-date
+        run: |
+          if ! git diff --exit-code conan.lock; then
+            echo "ERROR: conan.lock is out of date. Run scripts/lock.sh locally and commit the result."
+            exit 1
+          fi
+          echo "conan.lock is up-to-date"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,6 +39,7 @@ jobs:
           if [ "${COMPILER}" = "clang" ]; then
             CC=clang CXX=clang++ conan install . \
               --output-folder="build/${BUILD_TYPE}" \
+              --lockfile=conan.lock \
               --build=missing \
               -s build_type="${BUILD_TYPE_CAP}" \
               -s compiler=clang \
@@ -48,6 +49,7 @@ jobs:
           else
             conan install . \
               --output-folder="build/${BUILD_TYPE}" \
+              --lockfile=conan.lock \
               --build=missing \
               -s build_type="${BUILD_TYPE_CAP}" \
               -s compiler=gcc \

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           conan install . \
             --output-folder=build/coverage \
+            --lockfile=conan.lock \
             --build=missing \
             -s build_type=Debug \
             -s compiler=gcc \

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           CC=clang CXX=clang++ conan install . \
             --output-folder=build/debug \
+            --lockfile=conan.lock \
             --build=missing \
             -s build_type=Debug \
             -s compiler=clang \

--- a/conan.lock
+++ b/conan.lock
@@ -1,0 +1,11 @@
+{
+    "version": "0.5",
+    "requires": [
+        "nlohmann_json/3.11.3#45828be26eb619a2e04ca517bb7b828d%1701220705.259",
+        "gtest/1.14.0#f8f0757a574a8dd747d16af62d6eb1b7%1743410807.169",
+        "cpp-httplib/0.18.3#ad62795f35f0fecaea1fd4bdb7b949f0%1748426309.372"
+    ],
+    "build_requires": [],
+    "python_requires": [],
+    "config_requires": []
+}

--- a/scripts/lock.sh
+++ b/scripts/lock.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regenerate conan.lock using the canonical GCC-14/Debug/Linux/x86_64 profile
+# and show any diff against the committed lockfile.
+
+conan profile detect --force
+
+conan lock create . \
+  -s compiler=gcc \
+  -s compiler.version=14 \
+  -s compiler.libcxx=libstdc++11 \
+  -s compiler.cppstd=20 \
+  -s build_type=Debug \
+  -s os=Linux \
+  -s arch=x86_64
+
+git diff conan.lock


### PR DESCRIPTION
## Summary

- Generates and commits `conan.lock` (Conan 2.x format) pinning exact revision hashes for all three dependencies: `cpp-httplib/0.18.3`, `nlohmann_json/3.11.3`, and `gtest/1.14.0`
- Adds `--lockfile=conan.lock` to every `conan install` invocation in CI (`build-test.yml`, `code-coverage.yml`, `static-analysis.yml`, `_required.yml`) so the resolved graph is guaranteed to match the committed lockfile
- Adds a new `lockfile-integrity` job in `_required.yml` that regenerates the lockfile in CI and fails if it drifts from the committed version
- Adds `scripts/lock.sh` so developers can regenerate the lockfile locally with a single command

## Test plan

- [ ] `lockfile-integrity` job passes on this PR (lockfile matches what `conan lock create` produces on ubuntu-24.04 with GCC-14/Debug)
- [ ] All four `build-test` matrix legs (gcc+clang × debug+release) pass with `--lockfile=conan.lock`
- [ ] `code-coverage` and `static-analysis` jobs pass
- [ ] Verify manually: bump a dep version in `conanfile.py`, run `conan lock create .` without updating `conan.lock`, confirm `lockfile-integrity` would fail (non-empty `git diff conan.lock`)

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/claude-code)