### PR TITLE
ci(security): add CodeQL SAST workflow and fan-in to required checks

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -2,7 +2,7 @@ name: Required Checks
 
 on:
   workflow_run:
-    workflows: ["Build and Test", "Static Analysis", "Code Coverage"]
+    workflows: ["Build and Test", "Static Analysis", "Code Coverage", "CodeQL SAST"]
     types: [completed]
   pull_request:
     branches: [main]
@@ -103,6 +103,27 @@ jobs:
       - name: Skip (not triggered by this workflow)
         if: github.event_name != 'workflow_run'
         run: echo "Not a workflow_run event — pass (actual work done by Static Analysis workflow)"
+
+  security-codeql:
+    name: security/codeql
+    runs-on: ubuntu-24.04
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow.name == 'CodeQL SAST'
+    steps:
+      - name: Check CodeQL SAST result
+        if: github.event_name == 'workflow_run'
+        env:
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          if [ "${CONCLUSION}" != "success" ]; then
+            echo "CodeQL SAST workflow failed with: ${CONCLUSION}"
+            exit 1
+          fi
+          echo "CodeQL SAST passed"
+      - name: Skip (not triggered by this workflow)
+        if: github.event_name != 'workflow_run'
+        run: echo "Not a workflow_run event — pass (actual work done by CodeQL SAST workflow)"
 
   # ---------------------------------------------------------------------------
   # Independent jobs: run directly on push/pull_request

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,63 @@
+name: CodeQL SAST
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1'   # weekly, Monday 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: CodeQL / C++
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y ninja-build python3-pip
+
+      - name: Install Conan
+        run: pip3 install conan
+
+      - name: Configure Conan profile
+        run: |
+          conan profile detect --force
+          conan profile show
+
+      - name: Install Conan dependencies
+        run: conan install . --output-folder=build/ci --build=missing -s build_type=Release
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: cpp
+          queries: security-extended,security-and-quality
+
+      - name: Build (CodeQL traces the build)
+        run: |
+          cmake --preset ci -DCMAKE_TOOLCHAIN_FILE=build/ci/conan_toolchain.cmake
+          cmake --build --preset ci
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:cpp
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: true
+        with:
+          sarif_file: results.sarif
+          category: codeql-cpp


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml`: a dedicated CodeQL SAST workflow that triggers on `pull_request`, `push: main`, weekly schedule, and `workflow_dispatch`
- Builds the project with the existing `ci` CMake preset (Release + warnings-as-errors) so CodeQL performs full semantic dataflow analysis on compiled C++20 code
- Runs `security-extended` and `security-and-quality` query suites for comprehensive vulnerability coverage
- Uploads SARIF results to GitHub Security tab (`continue-on-error: true` on upload only — the `analyze` step itself gates the PR)
- Updates `_required.yml` to add `CodeQL SAST` to the `workflow_run` trigger list and a `security/codeql` fan-in job that enforces CodeQL results as a required check

## Test plan

- [ ] Confirm `CodeQL / C++` check appears in this PR's Checks tab after CI runs
- [ ] Confirm `security/codeql` appears in the Required Checks fan-in workflow run
- [ ] Navigate to Security → Code scanning in the repo to verify SARIF results upload
- [ ] Verify the `cmake --preset ci` build step succeeds in the CodeQL job log
- [ ] Confirm YAML validity: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml'))"` — passes locally

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)