### PR TITLE
fix(docker): add non-root USER directive and isolate conan via venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04 AS builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     cmake \
     ninja-build \
     g++ \
@@ -8,9 +8,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     python3 \
     python3-pip \
+    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --break-system-packages conan
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+ARG USER_NAME=builder
+
+RUN groupadd -g ${GROUP_ID} ${USER_NAME} \
+    && useradd -m -u ${USER_ID} -g ${GROUP_ID} ${USER_NAME} \
+    && chmod 755 /home/${USER_NAME} \
+    && mkdir -p /src && chown ${USER_ID}:${GROUP_ID} /src
+
+ENV VIRTUAL_ENV=/opt/conan-venv
+RUN python3 -m venv $VIRTUAL_ENV \
+    && $VIRTUAL_ENV/bin/pip install --upgrade pip \
+    && $VIRTUAL_ENV/bin/pip install "conan==2.12.1" \
+    && chown -R ${USER_ID}:${GROUP_ID} $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+USER ${USER_NAME}
 
 WORKDIR /src
 


### PR DESCRIPTION
## Summary

- Add `apt-get upgrade -y` to the apt layer for defense-in-depth CVE coverage
- Add `python3-venv` to the apt package list
- Create a non-root user/group via `ARG USER_ID=1000 / GROUP_ID=1000 / USER_NAME=builder` (all overridable at build time)
- Install `conan==2.12.1` into `/opt/conan-venv` — eliminates `pip3 install --break-system-packages` entirely
- Add `USER ${USER_NAME}` before `WORKDIR /src` so all build and test steps run as the non-root user

## Test plan

- [ ] `docker build -t charybdis-test .` — image builds successfully and all ctest pass
- [ ] `docker run --rm charybdis-test whoami` → prints `builder` (not `root`)
- [ ] `docker run --rm charybdis-test id` → `uid=1000 gid=1000`
- [ ] `grep break-system Dockerfile` → no matches
- [ ] `docker run --rm charybdis-test conan --version` → prints `2.12.1`
- [ ] CI required checks green

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)