### PR TITLE
fix(http_test_client): add 10 MB response body size limit to prevent OOM

### DIFF
--- a/include/projectcharybdis/http_test_client.hpp
+++ b/include/projectcharybdis/http_test_client.hpp
@@ -9,6 +9,8 @@ namespace projectcharybdis {
 /// Wraps cpp-httplib for REST API interactions with Agamemnon.
 class HttpTestClient {
  public:
+  static constexpr std::size_t kMaxBodyBytes = 10 * 1024 * 1024;  // 10 MB
+
   explicit HttpTestClient(const std::string& base_url = "http://localhost:8080");
 
   /// GET request, returns {status_code, body_json}

--- a/src/http_test_client.cpp
+++ b/src/http_test_client.cpp
@@ -26,6 +26,7 @@ HttpTestClient::Response HttpTestClient::get(const std::string& path) {
 
   auto res = cli.Get(path);
   if (!res) return {0, {}};
+  if (res->body.size() > kMaxBodyBytes) return {res->status, {{"error", "response_too_large"}}};
 
   nlohmann::json body;
   try {
@@ -47,6 +48,7 @@ HttpTestClient::Response HttpTestClient::del(const std::string& path) {
 
   auto res = cli.Delete(path);
   if (!res) return {0, {}};
+  if (res->body.size() > kMaxBodyBytes) return {res->status, {{"error", "response_too_large"}}};
 
   nlohmann::json resp_body;
   try {
@@ -65,6 +67,7 @@ HttpTestClient::Response HttpTestClient::post_raw(const std::string& path, const
 
   auto res = cli.Post(path, body, content_type);
   if (!res) return {0, {}};
+  if (res->body.size() > kMaxBodyBytes) return {res->status, {{"error", "response_too_large"}}};
 
   nlohmann::json resp_body;
   try {

--- a/test/src/test_http_client_unit.cpp
+++ b/test/src/test_http_client_unit.cpp
@@ -110,6 +110,27 @@ class MockServer {
       res.set_content(R"({"deleted":true})", "application/json");
     });
 
+    svr_.Get("/v1/oversized", [](const httplib::Request& /*req*/, httplib::Response& res) {
+      std::string big(HttpTestClient::kMaxBodyBytes + 1, 'x');
+      res.set_content(big, "text/plain");
+    });
+
+    svr_.Post("/v1/oversized-echo", [](const httplib::Request& /*req*/, httplib::Response& res) {
+      std::string big(HttpTestClient::kMaxBodyBytes + 1, 'x');
+      res.set_content(big, "text/plain");
+    });
+
+    svr_.Delete("/v1/oversized", [](const httplib::Request& /*req*/, httplib::Response& res) {
+      std::string big(HttpTestClient::kMaxBodyBytes + 1, 'x');
+      res.set_content(big, "text/plain");
+    });
+
+    svr_.Get("/v1/boundary", [](const httplib::Request& /*req*/, httplib::Response& res) {
+      // Exactly at the limit — not rejected
+      std::string exact(HttpTestClient::kMaxBodyBytes, 'x');
+      res.set_content(exact, "text/plain");
+    });
+
     thread_ = std::thread([this]() { svr_.listen_after_bind(); });
 
     // Wait until the server is actually accepting connections
@@ -179,6 +200,33 @@ TEST_F(HttpTestClientOnline, DelParsesJsonResponse) {
   auto [status, body] = client_->del("/v1/item");
   EXPECT_EQ(status, 200);
   EXPECT_TRUE(body.value("deleted", false));
+}
+
+TEST_F(HttpTestClientOnline, GetRejectsOversizedBody) {
+  auto [status, body] = client_->get("/v1/oversized");
+  EXPECT_EQ(body.value("error", ""), "response_too_large");
+}
+
+TEST_F(HttpTestClientOnline, PostRejectsOversizedBody) {
+  auto [status, body] = client_->post("/v1/oversized-echo", {{"x", 1}});
+  EXPECT_EQ(body.value("error", ""), "response_too_large");
+}
+
+TEST_F(HttpTestClientOnline, PostRawRejectsOversizedBody) {
+  auto [status, body] = client_->post_raw("/v1/oversized-echo", R"({"x":1})", "application/json");
+  EXPECT_EQ(body.value("error", ""), "response_too_large");
+}
+
+TEST_F(HttpTestClientOnline, DelRejectsOversizedBody) {
+  auto [status, body] = client_->del("/v1/oversized");
+  EXPECT_EQ(body.value("error", ""), "response_too_large");
+}
+
+TEST_F(HttpTestClientOnline, BoundaryBodyNotRejected) {
+  // Exactly kMaxBodyBytes — must not trigger the size guard
+  auto [status, body] = client_->get("/v1/boundary");
+  EXPECT_EQ(status, 200);
+  EXPECT_FALSE(body.value("error", "").find("response_too_large") != std::string::npos);
 }
 
 }  // namespace projectcharybdis


### PR DESCRIPTION
## Summary

- Adds `static constexpr std::size_t kMaxBodyBytes = 10 * 1024 * 1024` to `HttpTestClient`
- Checks `res->body.size() > kMaxBodyBytes` before `json::parse()` in `get()`, `del()`, and `post_raw()` — returning `{status, {"error":"response_too_large"}}` on breach
- Cap is 10 MB: 2× the 5 MB fuzzing payload in `test_payload_fuzzing.cpp`, providing a safety margin while catching runaway responses

## Test plan

- [ ] `HttpTestClientOnline.GetRejectsOversizedBody` — GET to oversized endpoint returns `{"error":"response_too_large"}`
- [ ] `HttpTestClientOnline.PostRejectsOversizedBody` — POST with oversized response returns same error
- [ ] `HttpTestClientOnline.PostRawRejectsOversizedBody` — `post_raw()` with oversized response returns same error
- [ ] `HttpTestClientOnline.DelRejectsOversizedBody` — DELETE to oversized endpoint returns same error
- [ ] `HttpTestClientOnline.BoundaryBodyNotRejected` — exactly `kMaxBodyBytes` bytes is not rejected
- [ ] All 29 existing unit tests continue to pass (no regression)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)