### PR TITLE
docs: add AGENTS.md — multi-agent coordination spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md — Multi-Agent Coordination for ProjectCharybdis
+
+This document specifies how agents in the HomericIntelligence mesh interact with
+ProjectCharybdis, which NATS subjects are used for task routing and metrics, and the
+handoff protocol for fault injection and recovery validation.
+
+## Agent Roles in the Mesh
+
+| Agent | Role |
+|-------|------|
+| **Agamemnon** | Orchestrator. Exposes the chaos REST API (`/v1/chaos/*`) and manages JetStream streams. |
+| **Nestor** | Coordination agent. Schedules and monitors tasks across the mesh. |
+| **Myrmidon workers** | Pull consumers. Execute tasks routed via `hi.myrmidon.hello.*`. |
+| **Argus** | Metrics consumer. Ingests resilience events from `hi.logs.>` into Prometheus. |
+| **Charybdis** | External test harness — not an agent. Invokes Agamemnon's chaos API and asserts recovery. |
+
+Charybdis is not a participant in the agent mesh. It exercises the mesh from the outside
+by injecting faults and observing whether the system returns to a healthy state.
+
+## How Charybdis Invokes Chaos
+
+All fault injection goes through Agamemnon's REST API. Charybdis does not modify NATS
+directly.
+
+### Endpoints
+
+| Method | Path | Effect |
+|--------|------|--------|
+| `POST` | `/v1/chaos/network-partition` | Split Tailscale nodes; test NATS JetStream reconnect |
+| `POST` | `/v1/chaos/latency` | Inject latency on a node; test backpressure and rate limiting |
+| `POST` | `/v1/chaos/kill` | Kill a named service; test restart and recovery |
+| `POST` | `/v1/chaos/queue-starve` | Stall all pull consumers on a subject; test no message loss |
+| `GET` | `/v1/chaos` | List active faults (returns `{"faults": [...]}`) |
+| `DELETE` | `/v1/chaos/{id}` | Remove an active fault by ID |
+
+### Fault Response Shape
+
+Every successful `POST /v1/chaos/<type>` returns a JSON object:
+
+```json
+{
+  "id": "<fault-id>",
+  "type": "<fault-type>",
+  "active": true
+}
+```
+
+The `id` field is required for the cleanup `DELETE` call.
+
+### Example Lifecycle
+
+```bash
+# 1. Inject a network partition
+curl -s -X POST http://localhost:8080/v1/chaos/network-partition
+
+# 2. Verify the fault is active
+curl -s http://localhost:8080/v1/chaos
+
+# 3. Assert recovery (poll until healthy or timeout)
+# (done in test code via wait_until())
+
+# 4. Remove the fault
+curl -s -X DELETE http://localhost:8080/v1/chaos/<fault-id>
+```
+
+## NATS Subject Namespaces
+
+| Subject | Purpose |
+|---------|---------|
+| `hi.myrmidon.hello.*` | Task routing to Myrmidon pull consumers |
+| `hi.logs.>` | Resilience metrics and events → Argus/Prometheus |
+
+**Isolation invariant:** Charybdis targets only test-namespaced subjects during fault
+injection. Production subjects (`hi.myrmidon.hello.*`, `hi.logs.>`) must never be
+directly targeted by fault injection. Tests that exercise these subjects create isolated
+instances with a unique suffix (via `random_suffix()`) to avoid cross-test interference.
+
+## Handoff Protocol
+
+The standard chaos scenario follows this sequence:
+
+1. **Inject** — Charybdis `POST`s a fault to `/v1/chaos/<type>`. Agamemnon applies the
+   fault to the mesh node or service and returns a fault `id`.
+
+2. **Observe** — Charybdis records the pre-fault state (e.g., task count, stream lag,
+   health check result) as a baseline for comparison.
+
+3. **Assert recovery** — Charybdis polls the system using `wait_until()` with a 30-second
+   timeout (configurable). The predicate checks that the mesh has returned to a healthy
+   state (e.g., Agamemnon `/health` responds, tasks reach `completed` status).
+
+4. **Clean up** — Regardless of assertion outcome, Charybdis `DELETE`s the fault via
+   `/v1/chaos/<fault-id>`. Cleanup must happen even on test failure to avoid leaving
+   faults active between test runs.
+
+5. **Validate baseline** — Charybdis performs a final assertion that the system state
+   matches the pre-fault baseline (e.g., no messages were lost, stream offsets are
+   consistent).
+
+Tests skip automatically (via `GTEST_SKIP()`) when Agamemnon is unreachable, so CI
+environments without a live mesh do not fail the build.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGAMEMNON_URL` | `http://localhost:8080` | Base URL for the Agamemnon REST API |
+| `NATS_URL` | `nats://localhost:4222` | NATS server URL for direct subject access |
+
+These are read at test startup via `agamemnon_url()` and `nats_url()` from
+`include/projectcharybdis/test_helpers.hpp`.
+
+## Security Boundary
+
+Charybdis is authorized to inject faults only within the bounds of a chaos testing
+engagement. The following constraints are enforced:
+
+- Fault injection targets only test-namespaced NATS subjects. No production subject
+  must be directly disrupted outside of an intentional resilience test.
+- The `DELETE /v1/chaos/{id}` cleanup step is mandatory. Tests that fail to clean up
+  faults are considered broken regardless of assertion outcome.
+- CI integration tests skip when Agamemnon is unreachable rather than failing; this
+  prevents flaky failures from blocking unrelated work.
+
+For responsible disclosure of security issues, see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ cmake --build --preset debug
 ctest --preset debug
 ```
 
+## Documentation
+
+- [AGENTS.md](AGENTS.md) — Multi-agent coordination: how agents invoke Charybdis, NATS subjects, and handoff protocols
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Development setup, workflow, and code standards
+- [SECURITY.md](SECURITY.md) — Responsible disclosure process
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Creates `AGENTS.md` at the repo root documenting multi-agent coordination for the HomericIntelligence ecosystem as it pertains to Charybdis
- Adds a Documentation section to `README.md` linking to `AGENTS.md`, `CONTRIBUTING.md`, and `SECURITY.md`

## What AGENTS.md Covers

- Agent roles in the mesh (Agamemnon, Nestor, Myrmidon, Argus, Charybdis)
- All five chaos REST endpoints with their response shape and a lifecycle example
- NATS subject namespaces (`hi.myrmidon.hello.*`, `hi.logs.>`) and the isolation invariant
- The 5-step handoff protocol: inject → observe → assert recovery → clean up → validate baseline
- Environment variables (`AGAMEMNON_URL`, `NATS_URL`) sourced from `test_helpers.hpp`
- Security boundary: fault injection must stay within test namespaces; cleanup is mandatory

## Test Plan

- [ ] Documentation-only change; no C++ source files modified
- [ ] All facts grounded in `CLAUDE.md`, `test_helpers.hpp`, `test_chaos_api.cpp`, and `test_protocol_correctness.cpp`
- [ ] Markdown standards from `CONTRIBUTING.md` followed: language-tagged code blocks, blank lines around blocks/lists/headings
- [ ] `README.md` link to `AGENTS.md` resolves correctly
- [ ] CI (build/test/lint/format) unaffected — no source changes

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)