### PR TITLE
docs(contributing): correct dependency manager from FetchContent to Conan 2.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ just format
 - **Standard**: C++20
 - **Formatting**: clang-format v17 (enforced by pre-commit hook)
 - **Build generator**: Ninja via CMakePresets.json
-- **Dependencies**: Managed via CMake FetchContent (GoogleTest)
+- **Dependencies**: Managed via Conan 2.x (see `conanfile.py`; includes GoogleTest, cpp-httplib, nlohmann_json)
 - **Sanitizers**: Use ASAN/TSAN for debugging memory and threading issues
 - **Test isolation**: All fault injection must target test-namespaced NATS subjects only
 


### PR DESCRIPTION
## Summary

- Fixes incorrect statement on CONTRIBUTING.md:179 that claimed dependencies are managed via CMake FetchContent
- Replaces it with accurate information: the project uses Conan 2.x (as defined in `conanfile.py`), managing GoogleTest, cpp-httplib, and nlohmann_json

## Test plan

- [ ] No code changes; documentation-only fix
- [ ] Verified against `conanfile.py` which confirms Conan 2.x manages all deps including `gtest/1.14.0`

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)