### PR TITLE
fix(iwyu): add explicit #include <set> and <string> in test_protocol_correctness.cpp

### DIFF
--- a/test/src/test_protocol_correctness.cpp
+++ b/test/src/test_protocol_correctness.cpp
@@ -8,6 +8,9 @@
 #include "projectcharybdis/http_test_client.hpp"
 #include "projectcharybdis/test_helpers.hpp"
 
+#include <set>
+#include <string>
+
 #include <gtest/gtest.h>
 
 namespace projectcharybdis {


### PR DESCRIPTION
## Summary

- Adds `#include <set>` and `#include <string>` to `test/src/test_protocol_correctness.cpp`
- `std::set<std::string>` at line 91 was relying on transitive inclusion from GTest/nlohmann headers, which is an IWYU violation
- This ensures the file compiles correctly on stricter standard library implementations

## Test plan

- [ ] Existing test suite passes (CI)
- [ ] No functional changes — headers only

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)