### PR TITLE
test: remove using namespace from 4 integration test files

### DIFF
--- a/test/src/test_chaos_api.cpp
+++ b/test/src/test_chaos_api.cpp
@@ -10,7 +10,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace projectcharybdis;
+namespace projectcharybdis {
 
 class ChaosApiTest : public ::testing::Test {
  protected:
@@ -92,3 +92,5 @@ TEST_F(ChaosApiTest, E04_RemoveFault) {
     EXPECT_NE(f.value("id", ""), fault_id) << "Fault should have been removed";
   }
 }
+
+}  // namespace projectcharybdis

--- a/test/src/test_malformed_messages.cpp
+++ b/test/src/test_malformed_messages.cpp
@@ -13,7 +13,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace projectcharybdis;
+namespace projectcharybdis {
 
 class MalformedMessageTest : public ::testing::Test {
  protected:
@@ -68,3 +68,5 @@ TEST_F(MalformedMessageTest, WrongContentType) {
   EXPECT_NE(status, 500);
   EXPECT_TRUE(client_->is_healthy());
 }
+
+}  // namespace projectcharybdis

--- a/test/src/test_payload_fuzzing.cpp
+++ b/test/src/test_payload_fuzzing.cpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace projectcharybdis;
+namespace projectcharybdis {
 
 class PayloadFuzzingTest : public ::testing::Test {
  protected:
@@ -123,3 +123,5 @@ TEST_F(PayloadFuzzingTest, E15_ExtraUnknownFields) {
 
   EXPECT_TRUE(client_->is_healthy());
 }
+
+}  // namespace projectcharybdis

--- a/test/src/test_protocol_correctness.cpp
+++ b/test/src/test_protocol_correctness.cpp
@@ -10,7 +10,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace projectcharybdis;
+namespace projectcharybdis {
 
 class ProtocolCorrectnessTest : public ::testing::Test {
  protected:
@@ -106,3 +106,5 @@ TEST_F(ProtocolCorrectnessTest, TaskStateOnlyPendingOrCompleted) {
     EXPECT_TRUE(state == "pending" || state == "completed") << "Unexpected state: " << state;
   }
 }
+
+}  // namespace projectcharybdis


### PR DESCRIPTION
## Summary

- Replaced `using namespace projectcharybdis;` with explicit `namespace projectcharybdis { }` blocks in all four integration test files
- Affected files: `test_chaos_api.cpp`, `test_malformed_messages.cpp`, `test_payload_fuzzing.cpp`, `test_protocol_correctness.cpp`
- Brings these files in line with the namespace hygiene already in place in unit tests (`test_helpers_unit.cpp`, `test_http_client_unit.cpp`, `test_main.cpp`)

Closes #34

## Test plan

- [ ] Verify build compiles cleanly with `cmake --preset debug && cmake --build --preset debug`
- [ ] Verify integration tests pass with `ctest --preset debug`
- [ ] Confirm no `using namespace projectcharybdis` remains in any test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)