### PR TITLE
refactor(test): extract agent_id extraction into helper function

### DIFF
--- a/include/projectcharybdis/test_helpers.hpp
+++ b/include/projectcharybdis/test_helpers.hpp
@@ -25,6 +25,12 @@ inline std::string random_suffix() {
   return std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
 }
 
+/// Extract agent_id from an agent JSON response (handles both flat and nested shapes)
+inline std::string extract_agent_id(const nlohmann::json& agent) {
+  return agent.contains("id") ? agent.value("id", "")
+                              : agent.value("agent", nlohmann::json{}).value("id", "");
+}
+
 /// Wait with timeout
 template <typename Pred>
 bool wait_until(Pred pred, std::chrono::seconds timeout = std::chrono::seconds{30}) {

--- a/test/src/test_protocol_correctness.cpp
+++ b/test/src/test_protocol_correctness.cpp
@@ -48,9 +48,7 @@ TEST_F(ProtocolCorrectnessTest, C10_IdempotentStreamCreation) {
                                                   {"owner", "e2e"},
                                                   {"role", "member"}});
   ASSERT_GE(s2, 200);
-  std::string agent_id = agent.contains("id")
-                             ? agent.value("id", "")
-                             : agent.value("agent", nlohmann::json{}).value("id", "");
+  std::string agent_id = extract_agent_id(agent);
 
   // Create task — exercises NATS publish to hi.myrmidon.hello.*
   auto [s3, task] =
@@ -76,9 +74,7 @@ TEST_F(ProtocolCorrectnessTest, TaskStateOnlyPendingOrCompleted) {
                                                   {"tags", nlohmann::json::array()},
                                                   {"owner", "e2e"},
                                                   {"role", "member"}});
-  std::string agent_id = agent.contains("id")
-                             ? agent.value("id", "")
-                             : agent.value("agent", nlohmann::json{}).value("id", "");
+  std::string agent_id = extract_agent_id(agent);
 
   auto [s3, task_resp] =
       client_->post("/v1/teams/" + team_id + "/tasks", {{"subject", "State test"},


### PR DESCRIPTION
## Summary

- Added `extract_agent_id(const nlohmann::json& agent)` inline helper to `test_helpers.hpp`
- Replaced the duplicated ternary at `test_protocol_correctness.cpp:51-53` and `:79-81` with calls to the new helper

## Test plan

- [ ] Build succeeds (`cmake --preset debug && cmake --build --preset debug`)
- [ ] Existing tests pass (`ctest --preset debug`)
- No logic change — pure refactor of duplicated extraction logic

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)