### PR TITLE
chore(renovate): remove dead FetchContent customManagers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,17 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["before 5am on Monday"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["CMakeLists\\.txt$"],
-      "matchStrings": [
-        "FetchContent_Declare\\([\\s\\S]*?GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^/]+/[^.]+)\\.git\\s+GIT_TAG\\s+(?<currentValue>v?[\\d.]+)"
-      ],
-      "datasourceTemplate": "github-tags",
-      "versioningTemplate": "semver"
-    }
-  ],
   "packageRules": [
     {
       "matchManagers": ["conan"],


### PR DESCRIPTION
## Summary

- Removes the `customManagers` section from `renovate.json` that contained a regex for `FetchContent_Declare` patterns
- This project uses Conan for C++ dependency management, not CMake FetchContent, so the regex never matched anything

## Test plan

- [ ] Verify `renovate.json` is valid JSON (no syntax errors)
- [ ] Confirm remaining `packageRules` for conan, pixi, and github-actions are intact

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)