### PR TITLE
fix(http_test_client): validate port range [0,65535] to prevent std::stoi throws

### DIFF
--- a/src/http_test_client.cpp
+++ b/src/http_test_client.cpp
@@ -3,6 +3,7 @@
 #include <httplib.h>
 #include <iostream>
 #include <regex>
+#include <stdexcept>
 
 namespace projectcharybdis {
 
@@ -12,7 +13,20 @@ HttpTestClient::HttpTestClient(const std::string& base_url) {
   std::smatch match;
   if (std::regex_match(base_url, match, url_re)) {
     host_ = match[1].str();
-    port_ = std::stoi(match[2].str());
+    const std::string port_str = match[2].str();
+    try {
+      const int parsed = std::stoi(port_str);
+      if (parsed < 0 || parsed > 65535) {
+        throw std::invalid_argument("port out of range");
+      }
+      port_ = parsed;
+    } catch (const std::out_of_range&) {
+      throw std::invalid_argument("Invalid port in URL '" + base_url + "': '" + port_str +
+                                  "' is not in range [0, 65535]");
+    } catch (const std::invalid_argument&) {
+      throw std::invalid_argument("Invalid port in URL '" + base_url + "': '" + port_str +
+                                  "' is not in range [0, 65535]");
+    }
   } else {
     host_ = "localhost";
     port_ = 8080;

--- a/test/src/test_http_client_unit.cpp
+++ b/test/src/test_http_client_unit.cpp
@@ -39,6 +39,29 @@ TEST(HttpTestClientUnit, HttpsUrlParsing) {
   EXPECT_FALSE(client.is_healthy());
 }
 
+// ── Port validation ───────────────────────────────────────────────────────────
+
+TEST(HttpTestClientPortValidation, PortAtLowerBound) {
+  // Port 0 is valid (OS assigns ephemeral port on bind); no throw on construction.
+  EXPECT_NO_THROW({ HttpTestClient client("http://127.0.0.1:0"); });
+}
+
+TEST(HttpTestClientPortValidation, PortAtUpperBound) {
+  EXPECT_NO_THROW({ HttpTestClient client("http://127.0.0.1:65535"); });
+}
+
+TEST(HttpTestClientPortValidation, PortJustAboveUpperBound) {
+  EXPECT_THROW({ HttpTestClient client("http://127.0.0.1:65536"); }, std::invalid_argument);
+}
+
+TEST(HttpTestClientPortValidation, PortFarOutOfRange) {
+  EXPECT_THROW({ HttpTestClient client("http://127.0.0.1:99999"); }, std::invalid_argument);
+}
+
+TEST(HttpTestClientPortValidation, PortOverflowsInt) {
+  EXPECT_THROW({ HttpTestClient client("http://127.0.0.1:2200000000"); }, std::invalid_argument);
+}
+
 // ── Connection-failure paths (port 1 is always refused) ───────────────────────
 
 class HttpTestClientOffline : public ::testing::Test {


### PR DESCRIPTION
## Summary

- Wraps the bare `std::stoi` call at `src/http_test_client.cpp:15` in try/catch blocks covering both `std::out_of_range` and `std::invalid_argument`
- Adds an explicit `[0, 65535]` range check after parsing; out-of-range values rethrow as `std::invalid_argument` with a descriptive message including the original URL and port string
- Adds `#include <stdexcept>` (previously only transitively included)

## Test plan

- [x] `PortAtLowerBound` — `http://127.0.0.1:0` constructs without throw
- [x] `PortAtUpperBound` — `http://127.0.0.1:65535` constructs without throw
- [x] `PortJustAboveUpperBound` — `http://127.0.0.1:65536` throws `std::invalid_argument`
- [x] `PortFarOutOfRange` — `http://127.0.0.1:99999` throws `std::invalid_argument`
- [x] `PortOverflowsInt` — `http://127.0.0.1:2200000000` throws `std::invalid_argument`
- [x] All 20 existing `HttpTestClient` unit tests continue to pass

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)