### PR TITLE
fix(justfile): add deps prerequisite to coverage recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ format:
 format-check:
   ./scripts/format.sh --check
 
-coverage:
+coverage: deps
   cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh
 
 clean:


### PR DESCRIPTION
`just coverage` on a clean checkout fails because Conan dependencies are not yet installed. Add `deps` as a prerequisite, consistent with `build: deps`.

Closes #48