### PR TITLE
chore(dependabot): require maintainer review for GitHub Actions SHA updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Require a maintainer to review before any SHA-pinned action update merges.
+    # This prevents auto-merge of dependabot PRs that modify .github/ without
+    # human inspection, as required by branch protection rules.
+    reviewers:
+      - HomericIntelligence/maintainers


### PR DESCRIPTION
Add a `reviewers` field to `dependabot.yml` so every weekly SHA-bump PR for GitHub Actions is automatically assigned to the `HomericIntelligence/maintainers` team. Without this, dependabot PRs that modify `.github/` could auto-merge without human inspection.

Closes #66