### PR TITLE
docs(msan): add hidden MSan preset skeleton with uninstrumented-lib guidance

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,6 +34,18 @@
       }
     },
     {
+      "name": "msan",
+      "displayName": "MSan (disabled — requires fully instrumented stdlib)",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ProjectCharybdis_BUILD_TESTING": "ON",
+        "ProjectCharybdis_ENABLE_SANITIZERS": "ON",
+        "ProjectCharybdis_SANITIZER": "msan"
+      }
+    },
+    {
       "name": "release",
       "displayName": "Release",
       "inherits": "base",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,6 +108,18 @@ When you report a vulnerability:
 - Social engineering attacks
 - Physical security
 
+## MemorySanitizer (MSan) Status
+
+MSan is intentionally absent from CI. Uninstrumented system libraries (libc++, libstdc++,
+glibc) produce unavoidable false positives because MSan requires **every** library in the
+process — including the C++ standard library — to be compiled with `-fsanitize=memory`.
+
+To enable MSan locally you must build a fully instrumented copy of libc++ from LLVM source
+and link against it. A skeleton CMake preset (`msan`, marked `hidden: true`) is recorded in
+`CMakePresets.json` to document what would be needed. Until a fully instrumented toolchain is
+available in CI, prefer ASAN (`--preset debug`) and TSan (`--preset tsan`) for dynamic
+analysis.
+
 ## Security Best Practices
 
 When contributing to ProjectCharybdis:


### PR DESCRIPTION
MSan was explicitly skipped because uninstrumented system libraries produce unavoidable false positives. This PR:

- Adds a `hidden: true` `msan` configure preset to `CMakePresets.json` as a documented skeleton for future enablement
- Adds a **MemorySanitizer (MSan) Status** section to `SECURITY.md` explaining the false-positive problem and what a full enablement (instrumented libc++) would require

Closes #58