### PR TITLE
fix(docker): use UID/GID 10001 to avoid apt-get upgrade GID collision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+ARG USER_ID=10001
+ARG GROUP_ID=10001
 ARG USER_NAME=builder
 
 RUN groupadd -g ${GROUP_ID} ${USER_NAME} \


### PR DESCRIPTION
## Summary

- Container Build and Publish is failing on main (run 25606018049) with `groupadd` exit code 4 (GID already in use)
- `apt-get upgrade` in ubuntu:24.04 installs packages that create a group/user with GID/UID 1000, causing the subsequent `groupadd -g 1000 builder` step to fail
- Fix: shift default `USER_ID`/`GROUP_ID` from 1000 to 10001 (well above the system-reserved range); explicit `--build-arg` overrides are unaffected

## Test plan

- [ ] Verify Container Build and Publish workflow goes green on this PR
- [ ] Verify `groupadd` step completes successfully in the Docker build log
- [ ] Verify resulting image runs as non-root user (UID 10001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)