### PR TITLE
fix(ci): Container Build and Publish failing on main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY conanfile.py ./
 COPY conan/ conan/
 RUN conan install . \
     --output-folder=build \
-    --profile=conan/profiles/default \
+    --profile:all=conan/profiles/default \
     --build=missing
 
 # Copy CMake configuration.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:24.04 AS builder
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     cmake \
     ninja-build \
-    g++ \
+    gcc-14 \
+    g++-14 \
     git \
     ca-certificates \
     python3 \
@@ -11,6 +12,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     python3-venv \
     libasan8 \
     libubsan1 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100 \
     && rm -rf /var/lib/apt/lists/*
 
 ARG USER_ID=10001


### PR DESCRIPTION
Repairs Container Build (run 25641154403).

**RC:** Conan 2 requires both host and build profiles. The Dockerfile passed only `--profile=conan/profiles/default`, which sets the host profile but leaves the build profile to default to `~/.conan2/profiles/default` — which doesn't exist in the freshly-built container. Conan failed with `The default build profile '/home/builder/.conan2/profiles/default' doesn't exist`.

**Fix:** Use `--profile:all=conan/profiles/default` to apply the repo's profile to both the host and build contexts in a single arg.

This workflow has never had a successful run since it was added in #153. This is the first successful change.

## Test plan
- [ ] Container Build and Publish workflow turns green on this PR
- [ ] After merge, the workflow stays green on `main`