### PR TITLE
chore: easy-issue sweep — refs #42 (lint.sh error visibility)

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-cmake --preset debug -DProjectCharybdis_ENABLE_CLANG_TIDY=OFF >/dev/null
+if ! cmake --preset debug -DProjectCharybdis_ENABLE_CLANG_TIDY=OFF >/dev/null; then
+  echo "lint.sh: cmake configure failed (preset=debug). Re-run without redirect for details:" >&2
+  echo "  cmake --preset debug -DProjectCharybdis_ENABLE_CLANG_TIDY=OFF" >&2
+  exit 1
+fi
 find "${ROOT_DIR}/include" "${ROOT_DIR}/src" "${ROOT_DIR}/test" \
   -name "*.cpp" -o -name "*.hpp" | \
   xargs clang-tidy -p "${ROOT_DIR}/build/debug" --config-file="${ROOT_DIR}/.clang-tidy" "$@"


### PR DESCRIPTION
## Summary

Easy-issue sweep batch. Most curated issues were already resolved on `main`; only #42 had remaining work.

### Changes
- **Refs #42** — `scripts/lint.sh` now wraps `cmake --preset debug` in an explicit `if !` block that prints a clear error message (and the re-run command) before `exit 1`. Previously, `>/dev/null` silenced stdout so contributors had no context when configure failed, even though `set -euo pipefail` did propagate the exit code.

### Verified ALREADY-DONE on `main`
- **#43** — `.editorconfig` present
- **#41** — `.dockerignore` present
- **#40** — `.github/PULL_REQUEST_TEMPLATE.md` and `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.md` present

### Skipped
- **#39** — Retry/circuit-breaker for `HttpTestClient` is non-trivial (needs backoff policy, breaker state machine, threshold config). Out of scope for easy-sweep batch; needs dedicated PR.

## Scope
1 file changed, 5 insertions(+), 1 deletion(-).

## Test plan
- [ ] `bash -n scripts/lint.sh` passes
- [ ] Manual: break cmake preset and confirm explicit error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)