### PR TITLE
fix(docker): install make and cc/c++ alternatives for Conan deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:24.04 AS builder
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     cmake \
+    make \
     ninja-build \
     gcc-14 \
     g++-14 \
@@ -14,6 +15,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     libubsan1 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 100 \
     && rm -rf /var/lib/apt/lists/*
 
 ARG USER_ID=10001


### PR DESCRIPTION
## Summary

The `builder` stage in `Dockerfile` had `cmake`/`ninja-build`/`gcc-14`/`g++-14` installed, but was missing the `make` binary and the `cc`/`c++` symlinks. Conan 2 defaults its dependency builds to the **"Unix Makefiles"** generator and relies on CMake's compiler auto-detection (which probes `cc`/`c++`), so `conan install` failed building `gtest/1.14.0` with:

```
CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
ERROR: gtest/1.14.0: Error in build() method, line 140
```

## Why this matters

This is failing identically on `main` (sha `e369d8f`, run [25643280533](https://github.com/HomericIntelligence/ProjectCharybdis/actions/runs/25643280533)). The **"Docker Build (and Publish on main)"** check is therefore red for *every* open PR. In particular it blocks **#221** (silent-failures sweep) — the same fix unblocks it.

## The fix

Minimal Dockerfile-only patch (3 added lines):

```diff
     cmake \
+    make \
     ninja-build \
     gcc-14 \
     ...
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 100 \
```

- `make` → satisfies Conan's default "Unix Makefiles" generator (`CMAKE_MAKE_PROGRAM`).
- `cc`/`c++` alternatives → CMake's compiler auto-detect finds `gcc-14`/`g++-14` via the canonical names without requiring `CC`/`CXX` env vars in the Conan profile.

No `|| true`, no `continue-on-error`, no `::warning::` — if the apt install fails, that is a real network/registry issue and we want CI to fail fast.

## Local verification

`podman build . --target builder` now:

1. Completes `conan install` cleanly (`gtest/1.14.0: Package 'de261bf...' built`, packaged 4 `.a` files, no CMake errors).
2. Proceeds through the full C++ build.
3. Reaches `ctest` (which then runs unit + offline tests successfully — Skipped tests are the network/Agamemnon ones that need infra, unrelated to the build).

## Test plan

- [ ] CI "Docker Build (and Publish on main)" check turns green on this PR.
- [ ] After merge, re-trigger CI on #221 — same check should turn green there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)