### PR TITLE
chore: easy-issue sweep 2026-05-11

### DIFF
--- a/.github/actions/conan-install/action.yml
+++ b/.github/actions/conan-install/action.yml
@@ -13,6 +13,18 @@ inputs:
     description: Output folder for conan install (e.g. build/debug)
     required: false
     default: ""
+  gcc_version:
+    description: GCC major version passed to conan -s compiler.version when compiler=gcc
+    required: false
+    default: "14"
+  clang_version:
+    description: Clang major version passed to conan -s compiler.version when compiler=clang
+    required: false
+    default: "18"
+  cppstd:
+    description: C++ standard passed to conan -s compiler.cppstd
+    required: false
+    default: "20"
 
 runs:
   using: composite
@@ -27,6 +39,9 @@ runs:
         BUILD_TYPE: ${{ inputs.build_type }}
         COMPILER: ${{ inputs.compiler }}
         OUTPUT_FOLDER: ${{ inputs.output_folder }}
+        GCC_VERSION: ${{ inputs.gcc_version }}
+        CLANG_VERSION: ${{ inputs.clang_version }}
+        CPPSTD: ${{ inputs.cppstd }}
       run: |
         BUILD_TYPE_CAP=$(echo "${BUILD_TYPE}" | awk '{print toupper(substr($0,1,1)) tolower(substr($0,2))}')
         FOLDER="${OUTPUT_FOLDER:-build/${BUILD_TYPE}}"
@@ -36,16 +51,16 @@ runs:
             --build=missing \
             -s build_type="${BUILD_TYPE_CAP}" \
             -s compiler=clang \
-            -s compiler.version=18 \
+            -s compiler.version="${CLANG_VERSION}" \
             -s compiler.libcxx=libstdc++11 \
-            -s compiler.cppstd=20
+            -s compiler.cppstd="${CPPSTD}"
         else
           conan install . \
             --output-folder="${FOLDER}" \
             --build=missing \
             -s build_type="${BUILD_TYPE_CAP}" \
             -s compiler=gcc \
-            -s compiler.version=14 \
+            -s compiler.version="${GCC_VERSION}" \
             -s compiler.libcxx=libstdc++11 \
-            -s compiler.cppstd=20
+            -s compiler.cppstd="${CPPSTD}"
         fi

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -274,14 +274,24 @@ jobs:
         with:
           fetch-depth: 0
       - name: Detect secrets
+        env:
+          GITLEAKS_VERSION: "8.21.2"
+          # SHA-256 of gitleaks_8.21.2_linux_x64.tar.gz from
+          # https://github.com/gitleaks/gitleaks/releases/tag/v8.21.2 — bumped in
+          # lockstep with GITLEAKS_VERSION so a hijacked download is rejected.
+          GITLEAKS_SHA256: "5bc41815076e6ed6ef8fbecc9d9b75bcae31f39029ceb55da08086315316e3ba"
         run: |
           set -euo pipefail
           # Extract gitleaks into a tmpdir outside the source tree so the
           # tarball's own README.md (which documents a sample sidekiq secret)
           # does not pollute the scan target.
           GITLEAKS_DIR="$(mktemp -d)"
-          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \
-            | tar xz -C "${GITLEAKS_DIR}"
+          TARBALL="${GITLEAKS_DIR}/gitleaks.tar.gz"
+          curl -sSfL --retry 3 \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            -o "${TARBALL}"
+          echo "${GITLEAKS_SHA256}  ${TARBALL}" | sha256sum --check --status
+          tar xz -C "${GITLEAKS_DIR}" -f "${TARBALL}"
           "${GITLEAKS_DIR}/gitleaks" detect --source . --redact --no-git
 
   schema-validation:

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -365,7 +365,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event_name != 'workflow_run'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install Conan
         run: pip3 install --user conan
       - name: Configure Conan profile

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
         run: conan install . --output-folder=build/ci --build=missing -s build_type=Release
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4
         with:
           languages: cpp
           queries: security-extended,security-and-quality
@@ -51,13 +51,13 @@ jobs:
           cmake --build --preset ci
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4
         with:
           category: /language:cpp
 
       - name: Upload SARIF to GitHub Security tab
         if: hashFiles('results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4
         with:
           sarif_file: results.sarif
           category: codeql-cpp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,24 @@ Every successful `POST /v1/chaos/<type>` returns a JSON object:
 
 The `id` field is required for the cleanup `DELETE` call.
 
+### `queue-starve` Targeting
+
+`POST /v1/chaos/queue-starve` is currently invoked by Charybdis tests with **no JSON
+body** (see `test/src/test_chaos_api.cpp` and `test_chaos_resilience.cpp`). With an
+empty body, Agamemnon stalls all pull consumers it knows about — this is the default
+behaviour exercised by the resilience suite.
+
+To target a specific NATS subject (rather than every subscriber), POST a JSON body of
+the form:
+
+```json
+{ "subject": "hi.test.<scenario>.<random-suffix>" }
+```
+
+Production subjects (`hi.myrmidon.hello.*`, `hi.logs.>`) must never be passed as the
+`subject` field. Tests that need to exercise these patterns must mint an isolated
+subject via `random_suffix()` per the **Isolation invariant** below.
+
 ### Example Lifecycle
 
 ```bash
@@ -86,8 +104,22 @@ The standard chaos scenario follows this sequence:
    health check result) as a baseline for comparison.
 
 3. **Assert recovery** — Charybdis polls the system using `wait_until()` with a 30-second
-   timeout (configurable). The predicate checks that the mesh has returned to a healthy
-   state (e.g., Agamemnon `/health` responds, tasks reach `completed` status).
+   default timeout. The predicate checks that the mesh has returned to a healthy state
+   (e.g., Agamemnon `/health` responds, tasks reach `completed` status). The timeout is
+   per-call: pass a `std::chrono::seconds` value as the second argument to override the
+   default for slow fault types (e.g. network-partition recovery often needs 60–120 s):
+
+   ```cpp
+   // Default 30s
+   const bool ok = wait_until([&]() { return client_->is_healthy(); });
+
+   // Custom timeout for a slow-recovery scenario
+   const bool recovered = wait_until(
+       [&]() { return client_->is_healthy(); },
+       std::chrono::seconds{120});
+   ```
+
+   See `include/projectcharybdis/test_helpers.hpp` for the full signature.
 
 4. **Clean up** — Regardless of assertion outcome, Charybdis `DELETE`s the fault via
    `/v1/chaos/<fault-id>`. Cleanup must happen even on test failure to avoid leaving

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,11 @@ For an overview of the full ecosystem, see the
 - [GitHub CLI](https://cli.github.com/) (`gh`)
 - [Pixi](https://pixi.sh/) for environment management
 - [Just](https://just.systems/) as the command runner
-- C++20 compiler (GCC 12+ or Clang 15+)
+- C++20 compiler (GCC 12+ or Clang 15+) — provided automatically by `pixi shell`
+  (via `cxx-compiler >= 1.7` in `pixi.toml`); manual compiler installation is only
+  needed if you build outside the Pixi environment.
+- [Conan 2.x](https://docs.conan.io/2/) for C++ dependency management
+  (`pip install 'conan>=2.0'`); see [Conan Setup](#conan-setup) below.
 
 ### Environment Setup
 
@@ -42,6 +46,27 @@ just build
 # Run tests to verify setup
 just test
 ```
+
+### Conan Setup
+
+Dependencies (GoogleTest, cpp-httplib, nlohmann_json) are managed by Conan 2.x. The
+Pixi environment ships Conan, so `pixi shell` is sufficient for most contributors. To
+bootstrap manually:
+
+```bash
+# 1. Install Conan 2.x (skipped if you use `pixi shell`)
+pip install 'conan>=2.0'
+
+# 2. Detect a default profile (creates ~/.conan2/profiles/default)
+conan profile detect --force
+
+# 3. Install dependencies into the build folder used by the debug preset
+conan install . --output-folder=build/debug --profile=conan/profiles/debug --build=missing
+```
+
+After Conan finishes, run `cmake --preset debug` followed by `just build` / `just test`.
+See [Conan Profiles](#conan-profiles) below for the difference between the `default`
+(Release) and `debug` profiles.
 
 ### Install Pre-commit Hooks
 
@@ -255,6 +280,55 @@ gh pr create --title "[Type] Brief description" --body "Closes #<issue-number>"
 ### Never Push Directly to Main
 
 The `main` branch is protected. All changes must go through pull requests.
+
+### CI Gates
+
+PRs must pass these required checks before merge:
+
+- **Build + Test** — `build-test.yml` (GCC and Clang).
+- **Static analysis** — clang-tidy via `static-analysis.yml`.
+- **Sanitizers** — ASan/UBSan via `sanitizers.yml`.
+- **CodeQL (SAST)** — `.github/workflows/codeql.yml` runs on every PR. Findings block
+  merge until resolved or triaged. To reproduce locally, install the
+  [CodeQL CLI](https://docs.github.com/en/code-security/codeql-cli) and run:
+
+  ```bash
+  codeql database create --language=cpp --command "cmake --build --preset debug" db
+  codeql analyze db --format=sarif-latest --output=results.sarif
+  ```
+
+  False positives should be triaged by the security maintainers; open an issue with
+  the SARIF excerpt rather than disabling the rule unilaterally.
+- **Secrets scan** — gitleaks via `_required.yml` (`security-secrets-scan` job).
+- **Container build + Trivy scan** — `container.yml` and the `release.yml` Trivy gate.
+
+## Release Process
+
+Releases are cut from `main` by tagging a semver `vX.Y.Z` tag. The release workflow
+(`.github/workflows/release.yml`) is triggered by `v*.*.*` tag pushes.
+
+```bash
+# After the release PR (CHANGELOG.md update) is merged to main
+git checkout main && git pull origin main
+git tag -a v0.1.0 -m "Release v0.1.0"
+git push origin v0.1.0
+```
+
+The first release (`v0.1.0`) is the bootstrap step that proves the workflow end-to-end.
+Subsequent releases follow the same procedure with the next semver tag.
+
+## Roadmap Maintenance
+
+`ROADMAP.md` mirrors the GitHub milestones. To keep them in sync:
+
+1. **When closing a milestone issue**, check off the matching item in `ROADMAP.md`
+   in the same PR (or the PR that closes the issue). Do not leave roadmap updates
+   for a separate cleanup pass.
+2. **When creating a new milestone**, add a corresponding section to `ROADMAP.md`
+   in the same change set (or a follow-up PR opened the same day).
+3. **When renaming or retargeting a milestone**, update `ROADMAP.md` to match.
+
+Drift between `ROADMAP.md` and the milestone list is treated as a documentation bug.
 
 ## Code Review
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:24.04 AS builder
+# Pinned to the multi-arch index digest of `ubuntu:24.04` resolved on 2026-05-11.
+# Renovate/Dependabot bumps must update both this builder stage and the runtime
+# stage below in lockstep so the audit trail stays reproducible. See #131 / #152.
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS builder
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     cmake \
@@ -72,7 +75,7 @@ RUN cmake --install build --prefix /install
 # ---------------------------------------------------------------------------
 # Runtime stage — minimal image containing only the compiled binary.
 # ---------------------------------------------------------------------------
-FROM ubuntu:24.04 AS runtime
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -48,6 +48,13 @@ Charybdis explicitly does not collect, log, or transmit:
   pass/fail outcomes, not payload content.
 - **Resilience metrics (`hi.logs.>`)** — retention is governed by the Argus stream
   configuration in ProjectArgus. Charybdis has no control over downstream retention.
+  The authoritative configuration lives in
+  [`HomericIntelligence/ProjectArgus`](https://github.com/HomericIntelligence/ProjectArgus)
+  under `configs/jetstream/` (stream name: `HI_LOGS`, subject filter: `hi.logs.>`).
+  Operators verifying compliance should consult that repo for the current
+  `MaxAge` / `MaxBytes` / `Discard` policy and the stream's owner team. If the
+  stream is renamed or its retention policy changes, this section must be updated
+  in the same PR.
 
 ## Sensitive Environment Guidance
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,34 @@ Install pre-commit hooks to enforce formatting and commit message conventions:
 pre-commit install
 ```
 
+## Container Image
+
+A pre-built runtime image is published to GitHub Container Registry on every push to
+`main` (and tagged release):
+
+- **Image:** `ghcr.io/homericintelligence/projectcharybdis`
+- **Tags:**
+  - `latest` — most recent build from `main`
+  - `sha-<short-sha>` — pinned to a specific commit SHA
+  - `vX.Y.Z` — published with each `vX.Y.Z` git tag (see Release Process in CONTRIBUTING.md)
+
+```bash
+# Pull the latest image
+docker pull ghcr.io/homericintelligence/projectcharybdis:latest
+
+# Or pin to a commit SHA for reproducibility
+docker pull ghcr.io/homericintelligence/projectcharybdis:sha-abc1234
+
+# Run the test suite against a remote Agamemnon
+docker run --rm \
+  -e AGAMEMNON_URL=http://agamemnon.internal:8080 \
+  -e NATS_URL=nats://nats.internal:4222 \
+  ghcr.io/homericintelligence/projectcharybdis:latest
+```
+
+The image is built from the multi-stage `Dockerfile` at the repo root using the Conan
+`default` (Release) profile and runs as a non-root user.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, commit message format, pull

--- a/include/projectcharybdis/http_test_client.hpp
+++ b/include/projectcharybdis/http_test_client.hpp
@@ -12,16 +12,26 @@ namespace projectcharybdis {
 
 /// Thin HTTP client for chaos/resilience GTest tests.
 /// Wraps cpp-httplib for REST API interactions with Agamemnon.
+///
+/// **Thread-safety:** Not thread-safe. The underlying `httplib::Client` is held as a
+/// member and reused across `get`/`post`/`del`/`post_raw` calls; `cpp-httplib`'s
+/// `Client` does not support concurrent requests on the same instance. Each test
+/// thread (or async task) must construct its own `HttpTestClient`. See issue #79.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)
 class HttpTestClient {
  public:
+  /// Maximum response body size accepted by the client. Responses exceeding this
+  /// limit are rejected and `Response::body` is replaced with
+  /// `{"error": "response_too_large"}` (status code is preserved). Callers asserting
+  /// on response shape must account for this contract.
   // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
   static constexpr std::size_t kMaxBodyBytes = 10 * 1024 * 1024;  // 10 MB
 
   explicit HttpTestClient(const std::string& base_url = "http://localhost:8080");
   ~HttpTestClient();
 
-  /// GET request, returns {status_code, body_json}
+  /// HTTP response. `body` is `{"error": "response_too_large"}` if the raw response
+  /// exceeded `kMaxBodyBytes`; the `status` field still reflects the server's reply.
   struct Response {
     int status;
     nlohmann::json body;
@@ -31,7 +41,8 @@ class HttpTestClient {
   [[nodiscard]] Response post(const std::string& path, const nlohmann::json& body = {});
   [[nodiscard]] Response del(const std::string& path);
 
-  /// POST with raw string body (for malformed payload tests)
+  /// POST with raw string body (for malformed payload tests). Subject to the same
+  /// `kMaxBodyBytes` response-size cap as the other methods.
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   [[nodiscard]] Response post_raw(const std::string& path, const std::string& body,
                                   const std::string& content_type = "application/json");


### PR DESCRIPTION
Bundle of low-risk EASY-sweep fixes for the 2026-05-11 ecosystem-wide pass.

## Closes (implemented)

- Closes #79 — \`HttpTestClient\` header now documents the single-threaded contract; each thread must own its instance.
- Closes #113 — \`.github/actions/conan-install/action.yml\` exposes \`gcc_version\`, \`clang_version\`, \`cppstd\` inputs (defaults 14/18/20).
- Closes #126 — \`github/codeql-action/{init,analyze,upload-sarif}@v4\` pinned to commit SHA \`68bde559…\`; loose \`actions/checkout@v6\` in \`_required.yml\` pinned to v6.0.2 SHA.
- Closes #129 — CONTRIBUTING.md gains a "CI Gates" section listing required checks (CodeQL, sanitizers, secrets, container) with local-repro commands.
- Closes #131 — \`Dockerfile\` builder \`FROM ubuntu:24.04\` pinned to multi-arch index digest \`sha256:c4a8d550…\`.
- Closes #141 — \`http_test_client.hpp\` documents \`kMaxBodyBytes\` contract (oversized → \`{"error":"response_too_large"}\`) on both the constant and \`Response\`.
- Closes #145 — AGENTS.md gains a \`queue-starve\` Targeting subsection (empty body → all consumers; \`{"subject": "…"}\` for a target subject).
- Closes #147 — AGENTS.md handoff protocol shows the per-call \`wait_until(pred, timeout)\` override pattern with a 120 s example.
- Closes #152 — runtime stage of \`Dockerfile\` pinned to the same Ubuntu digest as the builder stage.
- Closes #157 — README.md gains a "Container Image" section with GHCR pull/run examples and tag conventions.
- Closes #160 — CONTRIBUTING.md gains a "Release Process" section with the bootstrap \`v0.1.0\` tag command.
- Closes #167 — CONTRIBUTING.md Prerequisites note that \`pixi shell\` provides the C++ compiler automatically.
- Closes #171 — CONTRIBUTING.md gains a "Conan Setup" subsection covering install, profile detect, and \`conan install\`.
- Closes #175 — CONTRIBUTING.md gains a "Roadmap Maintenance" section (close-issue → tick ROADMAP item; new milestone → new section).
- Closes #181 — PRIVACY.md adds a concrete pointer to the Argus stream config (\`HI_LOGS\`, \`hi.logs.>\`, \`configs/jetstream/\` in ProjectArgus).
- Closes #64 — secrets-scan job downloads gitleaks v8.21.2 to a file and validates its sha256 (\`5bc41815…\`) before extraction.

## Closes (verified ALREADY-DONE on main as of \`7b5a11d\`)

The PR closes these via the \`Closes #N\` lines below; no diff was needed because main already satisfies the request:

- Closes #38 — \`test/src/test_http_client_unit.cpp:154-161\` already deadlines the mock-server startup loop at 5 s and throws on timeout.
- Closes #42 — \`scripts/lint.sh\` already runs cmake under \`if !\` with \`exit 1\`; no \`>/dev/null 2>&1 || true\` remains.
- Closes #69 — both \`_required.yml:256\` and \`release.yml:155\` already pin \`aquasecurity/trivy-action\` to commit SHA \`ed142fd0…\` (\`# v0.36.0\`).
- Closes #110 — \`v0.36.0\` is currently the **latest** \`aquasecurity/trivy-action\` release (verified via GitHub Releases API on 2026-05-11). Renovate will open a bump PR when a newer version ships; nothing to do today.
- Closes #170 — CONTRIBUTING.md preset references (\`debug\`, \`tsan\`) all match \`CMakePresets.json\`; Conan profile docs match the on-disk \`conan/profiles/{default,debug}\`. No outdated tooling references remain in the C++ Conventions section.

## Skipped / BLOCKED

- #44 (audit trail for chaos events) — design work; > 50 LoC sweep cap.
- #39 (retry/circuit-breaker in HttpTestClient) — feature work; > 50 LoC sweep cap.
- #117 (multi-profile conan.lock) — needs Conan binary verification across GCC/Clang; defer to dedicated investigation.
- #148 (Nestor invocation path in AGENTS.md) — issue notes the protocol is "once defined"; upstream definition not yet available.
- #161 (CHANGELOG markdownlint hook) — adding the hook now would block all doc commits because existing top-level markdown files have ~30 pre-existing MD022/MD032 violations. Needs a separate PR that fixes the legacy markdown first.
- #173 (assign ~120 issues to milestones) — manual triage task, not a code change.
- #174 (milestone field in issue/PR templates) — touches templates AND requires policy alignment with #173/#175; defer.
- #180 (audit CI log verbosity for payload capture) — investigation task; needs running tests against Agamemnon to observe.
- #183 (IWYU audit) — requires running iwyu-tool with compile_commands.json; investigation task.
- #196 (worktree pixi-init script) — needs new script and justfile recipe; > 50 LoC sweep cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)