### PR TITLE
build(conan): enforce conan.lock in all CI install invocations (#52)

### DIFF
--- a/.github/actions/conan-install/action.yml
+++ b/.github/actions/conan-install/action.yml
@@ -49,6 +49,7 @@ runs:
           CC=clang CXX=clang++ conan install . \
             --output-folder="${FOLDER}" \
             --build=missing \
+            --lockfile=conan.lock \
             -s build_type="${BUILD_TYPE_CAP}" \
             -s compiler=clang \
             -s compiler.version="${CLANG_VERSION}" \
@@ -58,6 +59,7 @@ runs:
           conan install . \
             --output-folder="${FOLDER}" \
             --build=missing \
+            --lockfile=conan.lock \
             -s build_type="${BUILD_TYPE_CAP}" \
             -s compiler=gcc \
             -s compiler.version="${GCC_VERSION}" \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
           conan profile show
 
       - name: Install Conan dependencies
-        run: conan install . --output-folder=build/ci --build=missing -s build_type=Release
+        run: conan install . --output-folder=build/ci --build=missing --lockfile=conan.lock -s build_type=Release
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,6 +36,7 @@ jobs:
           conan install . \
             --output-folder=build/ci \
             --build=missing \
+            --lockfile=conan.lock \
             -s build_type=Release \
             -s compiler=gcc \
             -s compiler.version=14 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
           conan install . \
             --output-folder=build/release \
             --build=missing \
+            --lockfile=conan.lock \
             -s build_type=Release \
             -s compiler=gcc \
             -s compiler.version=14 \

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -24,6 +24,7 @@ jobs:
           conan install . \
             --output-folder=build/asan \
             --build=missing \
+            --lockfile=conan.lock \
             -s build_type=Debug \
             -s compiler=gcc \
             -s compiler.version=14 \
@@ -53,6 +54,7 @@ jobs:
           conan install . \
             --output-folder=build/tsan \
             --build=missing \
+            --lockfile=conan.lock \
             -s build_type=Debug \
             -s compiler=gcc \
             -s compiler.version=14 \


### PR DESCRIPTION
## Summary
- `conan.lock` was committed in PR #115 but most `conan install` invocations were not passing `--lockfile=conan.lock`, so the resolved graph could still drift.
- Adds `--lockfile=conan.lock` to the composite action `.github/actions/conan-install/action.yml` (used by build-test, code-coverage, static-analysis, and the `_required` aggregator) and to the standalone install steps in `sanitizers.yml`, `integration-tests.yml`, `codeql.yml`, and `release.yml`.
- Closes #52.

## Test plan
- [x] `conan install` resolves against the committed lockfile locally
- [x] CI build matrix (gcc/clang x debug/release) passes with `--lockfile=conan.lock`
- [x] `lockfile-integrity` job still green (no changes to `conan.lock` itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)