### PR TITLE
refactor: expose timeout constants as constructor params (#81)

### DIFF
--- a/include/projectcharybdis/http_test_client.hpp
+++ b/include/projectcharybdis/http_test_client.hpp
@@ -27,7 +27,19 @@ class HttpTestClient {
   // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
   static constexpr std::size_t kMaxBodyBytes = 10 * 1024 * 1024;  // 10 MB
 
-  explicit HttpTestClient(const std::string& base_url = "http://localhost:8080");
+  /// Default connection timeout, in seconds. Used when callers do not override
+  /// `connection_timeout_sec` in the constructor.
+  static constexpr int kDefaultConnectionTimeoutSec = 5;
+  /// Default read timeout, in seconds. Used when callers do not override
+  /// `read_timeout_sec` in the constructor. Tests that exercise high-latency
+  /// fault injection (e.g. `POST /v1/chaos/latency`) should pass a larger value
+  /// to avoid false-positive timeouts.
+  static constexpr int kDefaultReadTimeoutSec = 10;
+
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  explicit HttpTestClient(const std::string& base_url = "http://localhost:8080",
+                          int connection_timeout_sec = kDefaultConnectionTimeoutSec,
+                          int read_timeout_sec = kDefaultReadTimeoutSec);
   ~HttpTestClient();
 
   /// HTTP response. `body` is `{"error": "response_too_large"}` if the raw response
@@ -50,9 +62,6 @@ class HttpTestClient {
   [[nodiscard]] bool is_healthy();
 
  private:
-  static constexpr int kConnectionTimeoutSec = 5;
-  static constexpr int kReadTimeoutSec = 10;
-
   std::string host_;
   int port_;
   std::unique_ptr<httplib::Client> client_;

--- a/src/http_test_client.cpp
+++ b/src/http_test_client.cpp
@@ -22,8 +22,9 @@ nlohmann::json parse_body(const httplib::Response& res) {
 }
 }  // namespace
 
-// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
-HttpTestClient::HttpTestClient(const std::string& base_url) {
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init,bugprone-easily-swappable-parameters)
+HttpTestClient::HttpTestClient(const std::string& base_url, int connection_timeout_sec,
+                               int read_timeout_sec) {
   // Parse "http://host:port" into host and port
   const std::regex url_re(R"(https?://([^:]+):(\d+))");
   // NOLINTNEXTLINE(misc-const-correctness) — mutated as regex_match output parameter
@@ -50,8 +51,8 @@ HttpTestClient::HttpTestClient(const std::string& base_url) {
     port_ = 8080;
   }
   client_ = std::make_unique<httplib::Client>(host_, port_);
-  client_->set_connection_timeout(kConnectionTimeoutSec);
-  client_->set_read_timeout(kReadTimeoutSec);
+  client_->set_connection_timeout(connection_timeout_sec);
+  client_->set_read_timeout(read_timeout_sec);
 }
 
 HttpTestClient::~HttpTestClient() = default;

--- a/test/src/test_http_client_unit.cpp
+++ b/test/src/test_http_client_unit.cpp
@@ -149,6 +149,14 @@ class MockServer {
       res.set_content(exact, "text/plain");
     });
 
+    svr_.Get("/v1/slow", [](const httplib::Request& /*req*/, httplib::Response& res) {
+      // Sleeps just long enough to exceed a sub-second read timeout but stay
+      // well under the default 10 s. Used to exercise constructor-supplied
+      // read-timeout overrides.
+      std::this_thread::sleep_for(std::chrono::seconds{1});
+      res.set_content(R"({"slow":true})", "application/json");
+    });
+
     thread_ = std::thread([this]() { svr_.listen_after_bind(); });
 
     // Wait until the server is actually accepting connections (5 s timeout)
@@ -259,6 +267,30 @@ TEST_F(HttpTestClientOnline, BoundaryBodyNotRejected) {
   auto [status, body] = client_->get("/v1/boundary");
   EXPECT_EQ(status, 200);
   EXPECT_FALSE(body.value("error", "").find("response_too_large") != std::string::npos);
+}
+
+// ── Constructor timeout overrides ─────────────────────────────────────────────
+
+TEST(HttpTestClientUnit, CustomTimeoutsAcceptedByConstructor) {
+  // Custom timeouts should not affect successful URL parsing or refused-port
+  // behaviour. Verifies the new constructor parameters are wired through
+  // without altering existing call paths.
+  HttpTestClient client("http://127.0.0.1:1", /*connection_timeout_sec=*/1,
+                        /*read_timeout_sec=*/2);
+  EXPECT_FALSE(client.is_healthy());
+}
+
+TEST(HttpTestClientUnit, LongReadTimeoutAllowsSlowResponse) {
+  // Mirrors the chaos/latency use case from issue #81: callers that inject
+  // latency need a read timeout longer than the default 10 s. The mock server's
+  // /v1/slow endpoint delays the response by 1 s; a client configured with a
+  // 5 s read timeout should still receive the body successfully.
+  MockServer mock;
+  HttpTestClient client("http://127.0.0.1:" + std::to_string(mock.port()),
+                        /*connection_timeout_sec=*/1, /*read_timeout_sec=*/5);
+  auto [status, body] = client.get("/v1/slow");
+  EXPECT_EQ(status, 200);
+  EXPECT_TRUE(body.value("slow", false));
 }
 
 }  // namespace projectcharybdis


### PR DESCRIPTION
## Summary
- Promote private `kConnectionTimeoutSec` / `kReadTimeoutSec` constants on `HttpTestClient` to public defaults (`kDefaultConnectionTimeoutSec` / `kDefaultReadTimeoutSec`) and accept matching optional constructor parameters.
- Backward compatible: the no-arg constructor and the existing `base_url`-only overload preserve the previous 5 s / 10 s behaviour via default arguments.
- Unblocks chaos/latency tests (`POST /v1/chaos/latency`) that need longer read timeouts without altering shared constants.
- Closes #81.

## Test plan
- [x] Existing `HttpTestClientUnit` / `HttpTestClientOffline` / `HttpTestClientOnline` suites pass unchanged (defaults preserve behaviour).
- [x] New `HttpTestClientUnit.CustomTimeoutsAcceptedByConstructor` verifies the new parameters flow through against a refused-port target.
- [x] New `HttpTestClientUnit.LongReadTimeoutAllowsSlowResponse` adds a 1 s-delayed `/v1/slow` endpoint to `MockServer` and confirms a client with a 5 s read timeout receives the body (chaos/latency use case).
- [x] `pre-commit run` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)