### PR TITLE
test(ctest): exclude REQUIRES_NATS-labeled tests from unit preset (#90)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -87,22 +87,44 @@
     {"name": "ci", "configurePreset": "ci"}
   ],
   "testPresets": [
-    {"name": "debug", "configurePreset": "debug", "output": {"outputOnFailure": true}},
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "output": {"outputOnFailure": true},
+      "filter": {"exclude": {"label": "REQUIRES_NATS"}}
+    },
     {
       "name": "asan",
       "configurePreset": "asan",
       "output": {"outputOnFailure": true},
-      "execution": {"timeout": 600}
+      "execution": {"timeout": 600},
+      "filter": {"exclude": {"label": "REQUIRES_NATS"}}
     },
     {
       "name": "tsan",
       "configurePreset": "tsan",
       "output": {"outputOnFailure": true},
-      "execution": {"timeout": 600}
+      "execution": {"timeout": 600},
+      "filter": {"exclude": {"label": "REQUIRES_NATS"}}
     },
-    {"name": "release", "configurePreset": "release", "output": {"outputOnFailure": true}},
-    {"name": "coverage", "configurePreset": "coverage", "output": {"outputOnFailure": true}},
-    {"name": "ci", "configurePreset": "ci", "output": {"outputOnFailure": true}},
+    {
+      "name": "release",
+      "configurePreset": "release",
+      "output": {"outputOnFailure": true},
+      "filter": {"exclude": {"label": "REQUIRES_NATS"}}
+    },
+    {
+      "name": "coverage",
+      "configurePreset": "coverage",
+      "output": {"outputOnFailure": true},
+      "filter": {"exclude": {"label": "REQUIRES_NATS"}}
+    },
+    {
+      "name": "ci",
+      "configurePreset": "ci",
+      "output": {"outputOnFailure": true},
+      "filter": {"exclude": {"label": "REQUIRES_NATS"}}
+    },
     {
       "name": "integration",
       "configurePreset": "ci",


### PR DESCRIPTION
## Summary
- Adds `filter.exclude.label: REQUIRES_NATS` to all unit-test presets (`ci`, `debug`, `release`, `asan`, `tsan`, `coverage`).
- Unit jobs (`build-test.yml`, `sanitizers.yml`, `code-coverage.yml`, `release.yml`) no longer pick up tests that would `GTEST_SKIP()` when no mock Agamemnon is running.
- The dedicated `integration` preset still uses `include.label: REQUIRES_NATS` (unchanged), so integration runs are unaffected.
- Closes #90

## Test plan
- [x] `ctest --preset ci` skips the REQUIRES_NATS-labelled tests
- [x] `ctest --preset debug` / `release` likewise
- [x] `ctest --preset integration` still includes them

Generated with [Claude Code](https://claude.com/claude-code)