### PR TITLE
fix(mock-agamemnon): reject non-empty bodies on /v1/chaos/test-empty (#89)

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,6 +17,10 @@ build: deps
 test:
   ctest --preset debug --output-on-failure
 
+# Standalone smoke tests for scripts/mock-agamemnon.py (no conan/cmake needed)
+test-mock:
+  python3 scripts/test-mock-agamemnon.py
+
 lint:
   ./scripts/lint.sh
 

--- a/scripts/mock-agamemnon.py
+++ b/scripts/mock-agamemnon.py
@@ -13,7 +13,7 @@ integration tests pass without a live HomericIntelligence mesh:
   POST /v1/agents                  → creates an agent record
   POST /v1/teams/<id>/tasks        → creates a task (pending)
   GET  /v1/tasks                   → lists tasks; marks completed only when no queue-starve active
-  POST /v1/chaos/test-empty        → accepts any body, returns 400 on empty JSON
+  POST /v1/chaos/test-empty        → diagnostic only: 400 on empty body, 400 on non-empty body
   POST /v1/agents (malformed)      → returns 400 on bad content-type or unparseable body
 
 Chaos effects simulated:
@@ -128,8 +128,18 @@ class AgamemnonHandler(BaseHTTPRequestHandler):
             if chaos_type not in CHAOS_TYPES:
                 self._send(404, {"error": "unknown chaos type"})
                 return
+            # /v1/chaos/test-empty is a diagnostic endpoint used only to
+            # exercise empty-body handling. It must reject ANY body — empty or
+            # non-empty — with 400 so callers cannot accidentally create a
+            # 'test-empty' fault record. See issue #89.
+            if chaos_type == "test-empty":
+                if empty:
+                    self._send(400, {"error": "empty body"})
+                else:
+                    self._send(400, {"error": "test-empty rejects non-empty body"})
+                return
             if empty:
-                # test-empty and other endpoints: empty body → 400
+                # Real chaos endpoints: empty body → 400
                 self._send(400, {"error": "empty body"})
                 return
             fault_id = str(uuid.uuid4())

--- a/scripts/test-mock-agamemnon.py
+++ b/scripts/test-mock-agamemnon.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Standalone smoke tests for scripts/mock-agamemnon.py.
+
+Runs without any third-party dependencies (no pytest, no requests). Boots the
+mock on an ephemeral port in a background thread and exercises HTTP endpoints
+with the stdlib's http.client. Exits non-zero on the first failed assertion.
+
+Run directly:
+
+    python3 scripts/test-mock-agamemnon.py
+
+Regression coverage for issue #89: /v1/chaos/test-empty must reject ALL bodies
+(empty and non-empty) so callers cannot accidentally register a 'test-empty'
+fault.
+"""
+
+from __future__ import annotations
+
+import http.client
+import importlib.util
+import socket
+import sys
+import threading
+import time
+from http.server import HTTPServer
+from pathlib import Path
+
+
+def _load_mock_module():
+    """Load scripts/mock-agamemnon.py as a module (it has a hyphen in its name)."""
+    mock_path = Path(__file__).resolve().parent / "mock-agamemnon.py"
+    spec = importlib.util.spec_from_file_location("mock_agamemnon", mock_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load module from {mock_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_ready(port: int, timeout: float = 5.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=0.5)
+            conn.request("GET", "/v1/health")
+            resp = conn.getresponse()
+            resp.read()
+            conn.close()
+            if resp.status == 200:
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError(f"mock did not become ready on :{port}")
+
+
+def _post(port: int, path: str, body: str, content_type: str = "application/json"):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2.0)
+    conn.request("POST", path, body=body, headers={"Content-Type": content_type})
+    resp = conn.getresponse()
+    data = resp.read().decode()
+    conn.close()
+    return resp.status, data
+
+
+def main() -> int:
+    mock = _load_mock_module()
+    port = _free_port()
+    server = HTTPServer(("127.0.0.1", port), mock.AgamemnonHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        _wait_ready(port)
+
+        # /v1/chaos/test-empty: empty body must return 400.
+        status, _ = _post(port, "/v1/chaos/test-empty", "")
+        assert status == 400, f"empty body: expected 400, got {status}"
+
+        # /v1/chaos/test-empty: non-empty JSON must ALSO return 400 (issue #89).
+        status, _ = _post(port, "/v1/chaos/test-empty", '{"active":true}')
+        assert status == 400, f"non-empty JSON: expected 400, got {status}"
+
+        # /v1/chaos/test-empty: non-empty text must return 400.
+        status, _ = _post(
+            port, "/v1/chaos/test-empty", "garbage", content_type="text/plain"
+        )
+        assert status == 400, f"non-empty text: expected 400, got {status}"
+
+        # No 'test-empty' fault should have been created.
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2.0)
+        conn.request("GET", "/v1/chaos")
+        resp = conn.getresponse()
+        body = resp.read().decode()
+        conn.close()
+        assert "test-empty" not in body, (
+            f"test-empty fault leaked into /v1/chaos: {body}"
+        )
+
+        # Other chaos endpoints still create fault records on valid JSON.
+        status, _ = _post(port, "/v1/chaos/latency", '{"delay_ms":10}')
+        assert status == 201, f"latency create: expected 201, got {status}"
+
+        # And still reject empty bodies.
+        status, _ = _post(port, "/v1/chaos/latency", "")
+        assert status == 400, f"latency empty: expected 400, got {status}"
+    finally:
+        server.shutdown()
+        server.server_close()
+    print("OK: mock-agamemnon /v1/chaos/test-empty validation passes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/src/test_malformed_messages.cpp
+++ b/test/src/test_malformed_messages.cpp
@@ -80,13 +80,11 @@ TEST_F(MalformedMessageTest, ChaosTestEmptyRejectsNonEmptyBody) {
   EXPECT_EQ(empty_status, 400);
 
   // Non-empty JSON: must also be rejected (no fault record created).
-  auto [json_status, _j] =
-      client_->post_raw("/v1/chaos/test-empty", R"({"active":true})");
+  auto [json_status, _j] = client_->post_raw("/v1/chaos/test-empty", R"({"active":true})");
   EXPECT_EQ(json_status, 400);
 
   // Non-empty plain text: same rejection.
-  auto [text_status, _t] =
-      client_->post_raw("/v1/chaos/test-empty", "anything", "text/plain");
+  auto [text_status, _t] = client_->post_raw("/v1/chaos/test-empty", "anything", "text/plain");
   EXPECT_EQ(text_status, 400);
 
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)

--- a/test/src/test_malformed_messages.cpp
+++ b/test/src/test_malformed_messages.cpp
@@ -71,6 +71,28 @@ TEST_F(MalformedMessageTest, EmptyBodies) {
   EXPECT_TRUE(client_->is_healthy());
 }
 
+// /v1/chaos/test-empty is a diagnostic endpoint and must reject non-empty
+// bodies with 400 — it must never create a 'test-empty' fault record.
+// Regression coverage for issue #89.
+TEST_F(MalformedMessageTest, ChaosTestEmptyRejectsNonEmptyBody) {
+  // Empty body: documented contract is 400.
+  auto [empty_status, _e] = client_->post_raw("/v1/chaos/test-empty", "");
+  EXPECT_EQ(empty_status, 400);
+
+  // Non-empty JSON: must also be rejected (no fault record created).
+  auto [json_status, _j] =
+      client_->post_raw("/v1/chaos/test-empty", R"({"active":true})");
+  EXPECT_EQ(json_status, 400);
+
+  // Non-empty plain text: same rejection.
+  auto [text_status, _t] =
+      client_->post_raw("/v1/chaos/test-empty", "anything", "text/plain");
+  EXPECT_EQ(text_status, 400);
+
+  // NOLINTNEXTLINE(readability-implicit-bool-conversion)
+  EXPECT_TRUE(client_->is_healthy());
+}
+
 // Wrong content-type header
 TEST_F(MalformedMessageTest, WrongContentType) {
   const nlohmann::json valid = {{"name", "wrong-ct"}};


### PR DESCRIPTION
## Summary
- /v1/chaos/test-empty is a diagnostic endpoint; it now returns 400 for any body (empty or non-empty) so callers cannot accidentally register a `test-empty` fault record.
- Adds a standalone Python smoke test (`scripts/test-mock-agamemnon.py`, runnable via `just test-mock`) and a C++ integration test asserting the 400 rejection across empty/JSON/text payloads.
- Closes #89

## Test plan
- [x] `just test-mock` passes locally
- [x] Existing `EmptyBodies` test still satisfied (empty POST returns 400, !=500)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)