### PR TITLE
ci(integration): upload ctest artifacts on failure (#93)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,3 +70,15 @@ jobs:
           AGAMEMNON_URL: http://localhost:8080
           NATS_URL: nats://localhost:4222
         run: ctest --preset integration
+
+      - name: Upload ctest logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ctest-logs
+          path: |
+            build/ci/Testing/Temporary/LastTest.log
+            build/ci/Testing/Temporary/LastTestsFailed.log
+            build/ci/Testing/Temporary/CTestCostData.txt
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Adds an `if: failure()` `actions/upload-artifact` step to `integration-tests.yml` that uploads `build/ci/Testing/Temporary/LastTest.log`, `LastTestsFailed.log`, and `CTestCostData.txt` so post-mortem debugging of failed integration runs has the full ctest output (sanitizer / verbose GTest dumps), not just the inline `outputOnFailure: true` excerpt.
- SHA-pinned to `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1` (same pin already used in `release.yml`), matching the policy from #65 / PR #236.
- `if-no-files-found: ignore` so configure/build failures (no Testing dir yet) don't error the upload step itself; `retention-days: 7` to bound storage.

Closes #93

## Test plan
- [x] YAML parses (`check-yaml` pre-commit will run in CI)
- [x] Step is gated by `if: failure()` so green runs cost nothing
- [ ] CI on this PR (build-test, static-analysis, lock-check, sanitizers, container, integration-tests, codeql)

Generated with [Claude Code](https://claude.com/claude-code)