### PR TITLE
ci(integration): verify NATS connectivity before tests (#92)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -95,11 +95,62 @@ jobs:
           cat "$log" || true
           exit 1
 
+      - name: Verify NATS connectivity
+        # Fail fast if NATS is unreachable, so REQUIRES_NATS tests can't
+        # silently skip the NATS code paths (#92). A real NATS server greets
+        # every new TCP connection with an INFO line; require it before tests.
+        shell: bash
+        run: |
+          set -euo pipefail
+          probe_nats() {
+            # Open a TCP connection to NATS and read the first line. Returns
+            # 0 only when the server emits a valid INFO greeting; nonzero on
+            # connection failure, timeout, or unexpected payload.
+            local line
+            set +e
+            line=$(timeout 2 bash -c \
+              'exec 3<>/dev/tcp/localhost/4222 && head -n 1 <&3' \
+              2>/dev/null)
+            local rc=$?
+            set -e
+            if [ "$rc" -ne 0 ]; then return 1; fi
+            printf '%s' "$line" | grep -q '^INFO '
+          }
+          for i in $(seq 1 30); do
+            if probe_nats; then
+              echo "NATS reachable after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: NATS server at nats://localhost:4222 did not greet within 30s"
+          exit 1
+
       - name: Run integration tests
         env:
           NATS_URL: nats://localhost:4222
         # AGAMEMNON_URL is exported by the previous step via $GITHUB_ENV
-        run: ctest --preset integration
+        run: ctest --preset integration --output-junit integration-results.xml
+
+      - name: Assert REQUIRES_NATS tests actually executed
+        # Guard against the integration preset matching zero tests (e.g. if the
+        # REQUIRES_NATS label is renamed/removed). ctest exits 0 when no tests
+        # match the filter, which would silently bypass the NATS suite (#92).
+        run: |
+          set -euo pipefail
+          xml=build/ci/integration-results.xml
+          if [ ! -f "$xml" ]; then
+            echo "ERROR: $xml not produced — ctest did not run"
+            exit 1
+          fi
+          count=$(python3 -c "import xml.etree.ElementTree as ET, sys; \
+            root = ET.parse('$xml').getroot(); \
+            print(sum(1 for _ in root.iter('testcase')))")
+          echo "integration testcases executed: $count"
+          if [ "$count" -lt 1 ]; then
+            echo "ERROR: zero REQUIRES_NATS tests ran — NATS integration silently skipped (#92)"
+            exit 1
+          fi
 
       - name: Upload ctest logs on failure
         if: failure()


### PR DESCRIPTION
## Summary

Closes #92.

The integration-tests workflow currently starts a NATS service and sets
`NATS_URL`, but nothing asserts the server is actually reachable or that
any `REQUIRES_NATS`-labeled test actually executed. If the NATS service
fails to start, or the integration test preset's label filter matches
zero tests, `ctest` exits 0 and the suite silently passes without
exercising any NATS code paths.

This PR adds two guardrails to `.github/workflows/integration-tests.yml`:

1. **Verify NATS connectivity** — opens a raw TCP connection to
   `localhost:4222` and requires the server's `INFO` greeting line
   before any tests run. Retries for 30s, then fails fast.
2. **Assert REQUIRES_NATS tests executed** — `ctest` now writes a
   JUnit XML via `--output-junit`; a post-step parses it with the
   Python stdlib and fails if zero testcases ran (catches label
   renames / filter regressions).

Out of scope: #90 (REQUIRES_NATS exclusion on unit presets, already
merged via #233) and #93 (ctest artifact upload on failure).

## Test plan

- [ ] CI integration-tests job passes (NATS reachable, REQUIRES_NATS tests > 0).
- [ ] Connectivity probe fails the workflow if NATS service is removed.
- [ ] Assertion step fails if the integration preset label is renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)