### PR TITLE
test(chaos): fix R03 kill test health recovery (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,20 +55,44 @@ ctest --preset debug
 ## Environment Variables
 
 These variables configure which services Charybdis connects to during testing.
-Both are optional; defaults point to local development instances.
+All are optional; defaults point to local development instances.
 
-| Variable        | Required | Default                    | Description                          |
-|-----------------|----------|----------------------------|--------------------------------------|
-| `AGAMEMNON_URL` | No       | `http://localhost:8080`    | Base URL of the Agamemnon chaos API  |
-| `NATS_URL`      | No       | `nats://localhost:4222`    | NATS server used for JetStream tests |
+| Variable                   | Required | Default                    | Description                                                                 |
+|----------------------------|----------|----------------------------|-----------------------------------------------------------------------------|
+| `AGAMEMNON_URL`            | No       | `http://localhost:8080`    | Base URL of the Agamemnon chaos API                                         |
+| `NATS_URL`                 | No       | `nats://localhost:4222`    | NATS server used for JetStream tests                                        |
+| `CHAOS_RECOVERY_TIMEOUT_S` | No       | `10`                       | Seconds R03 waits for Agamemnon to come back after a `kill` fault          |
 
 Example:
 
 ```bash
 export AGAMEMNON_URL=http://agamemnon.internal:8080
 export NATS_URL=nats://nats.internal:4222
+export CHAOS_RECOVERY_TIMEOUT_S=30   # raise if your supervisor restart is slow
 just test
 ```
+
+### R03 kill-test restart supervisor
+
+`ChaosResilienceTest.R03KillServiceHealthDegrades` asserts that Agamemnon's
+`/v1/health` endpoint recovers after a `kill` fault. The chaos endpoint itself
+does **not** restart Agamemnon — it only kills the process. Recovery therefore
+requires an external supervisor:
+
+* `systemd` unit with `Restart=on-failure`
+* Kubernetes pod (any `restartPolicy` other than `Never`)
+* Docker `--restart=always` / `unless-stopped`
+* equivalent process supervisor (`s6`, `runit`, `supervisord`, …)
+
+Environments without such a supervisor must exclude R03 from their ctest run:
+
+```bash
+ctest --label-exclude REQUIRES_RESTART_SUPERVISOR
+```
+
+Slower restart policies (back-off, image pull, readiness gates) should raise
+`CHAOS_RECOVERY_TIMEOUT_S` to a value that comfortably exceeds the supervisor's
+worst-case restart latency.
 
 ## Architecture
 

--- a/include/projectcharybdis/test_helpers.hpp
+++ b/include/projectcharybdis/test_helpers.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <chrono>
+#include <cstdlib>
+#include <exception>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <thread>
@@ -19,6 +21,32 @@ inline std::string nats_url() {
   // NOLINTNEXTLINE(concurrency-mt-unsafe)
   const char* env = std::getenv("NATS_URL");
   return (env != nullptr) ? std::string{env} : std::string{"nats://localhost:4222"};
+}
+
+/// Get chaos kill-fault recovery timeout (seconds) from environment, or default.
+///
+/// Recovery after a kill fault depends on an external supervisor (systemd unit
+/// with Restart=on-failure, Kubernetes pod restart, Docker --restart=always,
+/// etc.) bringing Agamemnon back up. The default 10s window is appropriate for
+/// fast-restart supervisors; slower restart policies (back-off, image pull,
+/// readiness probes) require a longer window. Non-positive or unparseable
+/// values fall back to the default.
+inline std::chrono::seconds chaos_recovery_timeout() {
+  constexpr std::chrono::seconds kDefault{10};
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  const char* env = std::getenv("CHAOS_RECOVERY_TIMEOUT_S");
+  if (env == nullptr || *env == '\0') {
+    return kDefault;
+  }
+  try {
+    const int parsed = std::stoi(env);
+    if (parsed <= 0) {
+      return kDefault;
+    }
+    return std::chrono::seconds{parsed};
+  } catch (const std::exception&) {
+    return kDefault;
+  }
 }
 
 /// Generate a random string for test isolation

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,14 +38,33 @@ target_link_libraries(${PROJECT_NAME}_integration_tests
     nlohmann_json::nlohmann_json
     GTest::gtest_main)
 
-# Discover all integration tests except R04 (which needs an extra label).
+# Discover integration tests, partitioning by capability requirements.
 # gtest_discover_tests runs POST_BUILD, so set_tests_properties cannot be used
-# after the call — tests don't exist at configure time. Instead, use two
-# separate discovery calls with gtest_filter to partition the test suite.
+# after the call — tests don't exist at configure time. Instead, use separate
+# discovery calls with gtest_filter to partition the test suite by labels.
+#
+# Partition:
+#   * .nats       — needs Agamemnon + NATS only
+#   * .supervisor — additionally needs an external restart supervisor (R03)
+#   * .myrmidon   — additionally needs a live myrmidon pull consumer (R04)
+set(_charybdis_supervisor_filter "ChaosResilienceTest.R03KillServiceHealthDegrades")
+set(_charybdis_myrmidon_filter "ChaosResilienceTest.R04_QueueStarve_ConsumerStalls")
+
 gtest_discover_tests(${PROJECT_NAME}_integration_tests
     TEST_SUFFIX .nats
-    EXTRA_ARGS "--gtest_filter=-ChaosResilienceTest.R04_QueueStarve_ConsumerStalls"
+    EXTRA_ARGS "--gtest_filter=-${_charybdis_supervisor_filter}:${_charybdis_myrmidon_filter}"
     PROPERTIES LABELS "REQUIRES_NATS")
+
+# R03KillServiceHealthDegrades additionally requires an external restart supervisor
+# (systemd, Kubernetes, Docker --restart=always) to bring Agamemnon back after the
+# kill fault. Without one, the process stays dead and the recovery assertion will
+# always time out. CI environments without a supervisor can skip with:
+#   ctest --label-exclude REQUIRES_RESTART_SUPERVISOR
+# Recovery timeout is tunable via CHAOS_RECOVERY_TIMEOUT_S (seconds).
+gtest_discover_tests(${PROJECT_NAME}_integration_tests
+    TEST_SUFFIX .supervisor
+    EXTRA_ARGS "--gtest_filter=${_charybdis_supervisor_filter}"
+    PROPERTIES LABELS "REQUIRES_NATS;REQUIRES_RESTART_SUPERVISOR")
 
 # R04_QueueStarve_ConsumerStalls additionally requires a live myrmidon pull consumer.
 # Without one, the task will never advance to 'completed' and the recovery assertion
@@ -53,5 +72,5 @@ gtest_discover_tests(${PROJECT_NAME}_integration_tests
 #   ctest --label-exclude REQUIRES_MYRMIDON
 gtest_discover_tests(${PROJECT_NAME}_integration_tests
     TEST_SUFFIX .myrmidon
-    EXTRA_ARGS "--gtest_filter=ChaosResilienceTest.R04_QueueStarve_ConsumerStalls"
+    EXTRA_ARGS "--gtest_filter=${_charybdis_myrmidon_filter}"
     PROPERTIES LABELS "REQUIRES_NATS;REQUIRES_MYRMIDON")

--- a/test/src/test_chaos_resilience.cpp
+++ b/test/src/test_chaos_resilience.cpp
@@ -137,6 +137,18 @@ TEST_F(ChaosResilienceTest, R02LatencyInjectionSlowResponse) {
 }
 
 // R03: Kill fault → health degrades → recovers after removal (or auto-restart)
+//
+// REQUIRES_NATS              — Agamemnon must be reachable (inherits suite default).
+// REQUIRES_RESTART_SUPERVISOR — An external supervisor must auto-restart Agamemnon
+//   after the kill fault (e.g. systemd Restart=on-failure, Kubernetes pod restart,
+//   Docker --restart=always). Without one, the process stays dead and the recovery
+//   assertion will always time out. Skip in CI without a supervisor with:
+//     ctest --label-exclude REQUIRES_RESTART_SUPERVISOR
+//
+// The recovery window is configurable via CHAOS_RECOVERY_TIMEOUT_S (seconds);
+// see test_helpers.hpp::chaos_recovery_timeout(). The default (10s) suits
+// fast-restart supervisors; slower restart policies (back-off, image pull,
+// readiness gates) should raise it.
 TEST_F(ChaosResilienceTest, R03KillServiceHealthDegrades) {
   const auto fault = inject("/v1/chaos/kill");
   const std::string fault_id = fault.value("id", "");
@@ -149,14 +161,19 @@ TEST_F(ChaosResilienceTest, R03KillServiceHealthDegrades) {
       wait_until([&]() { return !client_->is_healthy(); }, std::chrono::seconds{5});
   EXPECT_TRUE(degraded) << "Expected health to degrade within 5s of kill fault";
 
-  // Remove fault (allows auto-restart)
+  // Remove fault. NOTE: this only clears Charybdis's fault registry; it does
+  // NOT restart Agamemnon. Recovery requires an external supervisor to relaunch
+  // the killed process. The injected_ids_ tracking is still cleared so TearDown
+  // does not double-DELETE the fault.
   remove(fault_id);
 
-  // Assert recovery: health returns ok within 10s
+  // Assert recovery: health returns ok within the configured timeout window.
+  const auto recovery_timeout = chaos_recovery_timeout();
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)
-  const bool recovered =
-      wait_until([&]() { return client_->is_healthy(); }, std::chrono::seconds{10});
-  EXPECT_TRUE(recovered) << "Agamemnon health did not recover within 10s after removing kill fault";
+  const bool recovered = wait_until([&]() { return client_->is_healthy(); }, recovery_timeout);
+  EXPECT_TRUE(recovered) << "Agamemnon health did not recover within " << recovery_timeout.count()
+                         << "s after removing kill fault — verify an external restart supervisor "
+                            "is configured, or raise CHAOS_RECOVERY_TIMEOUT_S";
 }
 
 // R04: Queue-starve → task stays pending → advances to completed after removal

--- a/test/src/test_helpers_unit.cpp
+++ b/test/src/test_helpers_unit.cpp
@@ -2,12 +2,15 @@
  * @file test_helpers_unit.cpp
  * @brief Unit tests for test_helpers.hpp inline utilities.
  *
- * Exercises agamemnon_url(), nats_url(), random_suffix(), and wait_until()
- * to ensure the include/projectcharybdis/test_helpers.hpp lines are covered.
+ * Exercises agamemnon_url(), nats_url(), chaos_recovery_timeout(),
+ * random_suffix(), and wait_until() to ensure the
+ * include/projectcharybdis/test_helpers.hpp lines are covered.
  */
 
 #include "projectcharybdis/test_helpers.hpp"
 
+#include <chrono>
+#include <cstdlib>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -26,6 +29,38 @@ TEST(TestHelpersUnit, NatsUrlDefaultsToLocalhost) {
   const std::string url = nats_url();
   EXPECT_FALSE(url.empty());
   EXPECT_NE(url.find("localhost"), std::string::npos);
+}
+
+TEST(TestHelpersUnit, ChaosRecoveryTimeoutDefaultsTo10s) {
+  // Unset the var so the default branch is exercised.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::unsetenv("CHAOS_RECOVERY_TIMEOUT_S");
+  EXPECT_EQ(chaos_recovery_timeout(), std::chrono::seconds{10});
+}
+
+TEST(TestHelpersUnit, ChaosRecoveryTimeoutHonorsValidEnv) {
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::setenv("CHAOS_RECOVERY_TIMEOUT_S", "45", 1);
+  EXPECT_EQ(chaos_recovery_timeout(), std::chrono::seconds{45});
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::unsetenv("CHAOS_RECOVERY_TIMEOUT_S");
+}
+
+TEST(TestHelpersUnit, ChaosRecoveryTimeoutFallsBackOnGarbage) {
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::setenv("CHAOS_RECOVERY_TIMEOUT_S", "not-a-number", 1);
+  EXPECT_EQ(chaos_recovery_timeout(), std::chrono::seconds{10});
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::setenv("CHAOS_RECOVERY_TIMEOUT_S", "0", 1);
+  EXPECT_EQ(chaos_recovery_timeout(), std::chrono::seconds{10});
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::setenv("CHAOS_RECOVERY_TIMEOUT_S", "-5", 1);
+  EXPECT_EQ(chaos_recovery_timeout(), std::chrono::seconds{10});
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::setenv("CHAOS_RECOVERY_TIMEOUT_S", "", 1);
+  EXPECT_EQ(chaos_recovery_timeout(), std::chrono::seconds{10});
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::unsetenv("CHAOS_RECOVERY_TIMEOUT_S");
 }
 
 TEST(TestHelpersUnit, RandomSuffixIsNonEmpty) {


### PR DESCRIPTION
## Summary

`ChaosResilienceTest.R03KillServiceHealthDegrades` previously asserted that Agamemnon's `/v1/health` recovers within a hard-coded 10s after a `kill` fault, silently assuming an auto-restart mechanism existed. The chaos endpoint only kills the process — recovery requires an external supervisor (systemd, Kubernetes, Docker `--restart`, etc.). Without one, the test was guaranteed to flake on supervisor-less runners.

This PR:

- Documents the restart-supervisor dependency in the test body, in the README, and via the new `REQUIRES_RESTART_SUPERVISOR` ctest label (mirroring how R04 handles `REQUIRES_MYRMIDON`). Supervisor-less CI can now skip cleanly with `ctest --label-exclude REQUIRES_RESTART_SUPERVISOR`.
- Adds `chaos_recovery_timeout()` in `test_helpers.hpp`, honoring a new `CHAOS_RECOVERY_TIMEOUT_S` env var (default `10`) so slow-restart policies (back-off, image pull, readiness gates) can raise the window without code edits.
- Adds unit-test coverage for the helper: default, valid env, garbage, zero, negative, empty.

Files changed: 5 (140 insertions / 17 deletions).

Closes #96 — follow-up from #14.

## Test plan

- [ ] CI: `Build & Test` runs the new `TestHelpersUnit.ChaosRecoveryTimeout*` cases and existing R03 still discovers under the new `.supervisor` suffix.
- [ ] CI: clang-tidy / static-analysis pass on the new env-parsing branch (`std::stoi` + `std::exception` catch are NOLINT-annotated only where required by the project's existing `concurrency-mt-unsafe` policy).
- [ ] Manual smoke (post-merge): on a runner without a restart supervisor, `ctest --label-exclude REQUIRES_RESTART_SUPERVISOR` no longer runs R03; with `CHAOS_RECOVERY_TIMEOUT_S=30` exported, R03 honors the extended window.

Generated with [Claude Code](https://claude.com/claude-code)