### PR TITLE
docs: distinct CoC/SECURITY contacts (#49)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -48,7 +48,7 @@ online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders
-responsible for enforcement at <4211002+mvillmow@users.noreply.github.com>. All complaints will be reviewed and investigated.
+responsible for enforcement at <conduct@homericintelligence.com>. All complaints will be reviewed and investigated.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ We take security seriously. If you discover a security vulnerability, please rep
 
 ### Email (Preferred)
 
-Send an email to: **<4211002+mvillmow@users.noreply.github.com>**
+Send an email to: **<security@homericintelligence.com>**
 
 Or use the GitHub private vulnerability reporting feature if available.
 
@@ -135,7 +135,7 @@ When contributing to ProjectCharybdis:
 For security-related questions that are not vulnerability reports:
 
 - Open a GitHub Discussion with the "security" tag
-- Email: <4211002+mvillmow@users.noreply.github.com>
+- Email: <security@homericintelligence.com>
 
 ---
 


### PR DESCRIPTION
## Summary
Replaces the shared GitHub noreply contact address used in both `CODE_OF_CONDUCT.md` and `SECURITY.md` with purpose-specific aliases per the maintainer's implementation plan:

- `CODE_OF_CONDUCT.md` line 51: `conduct@homericintelligence.com`
- `SECURITY.md` lines 13 and 138: `security@homericintelligence.com`

Closes #49

## Test plan
- [x] `grep -nE "noreply" CODE_OF_CONDUCT.md SECURITY.md` returns no matches
- [x] Diff limited to the three intended replacements (2 files, 3 insertions / 3 deletions)
- [ ] CI green (markdown-only change — no C++ impact)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>