### PR TITLE
ci(security): remove gitleaks --no-git to scan full history (#68)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -292,7 +292,10 @@ jobs:
             -o "${TARBALL}"
           echo "${GITLEAKS_SHA256}  ${TARBALL}" | sha256sum --check --status
           tar xz -C "${GITLEAKS_DIR}" -f "${TARBALL}"
-          "${GITLEAKS_DIR}/gitleaks" detect --source . --redact --no-git
+          # Scan full git history (fetch-depth: 0 above ensures it's available).
+          # `--no-git` would only scan the working tree, missing secrets in
+          # prior commits — see #68 follow-up to #9.
+          "${GITLEAKS_DIR}/gitleaks" detect --source . --redact
 
   schema-validation:
     name: schema-validation


### PR DESCRIPTION
## Summary
- Issue #68 had two halves. The `|| true` half was already removed in #221 (commit 897c8fb, Bucket A refactor).
- This PR removes the remaining `--no-git` flag from `gitleaks detect` in `.github/workflows/_required.yml`. With `fetch-depth: 0` already set on the checkout step, `--no-git` was redundantly suppressing the history scan and reducing gitleaks coverage to the working tree only — secrets committed in prior history could slip past CI undetected.

## Diff
1 file, +4/-1 LOC (well under the MEDIUM 3-file/100-LOC cap).

## Test plan
- [ ] `security/secrets-scan` job remains green on this PR (no secrets in current tree or history)
- [ ] Branch protection check `security/secrets-scan` continues to gate merges

Closes #68

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>