### PR TITLE
feat(chaos): audit trail for injection events (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ All are optional; defaults point to local development instances.
 | `AGAMEMNON_URL`            | No       | `http://localhost:8080`    | Base URL of the Agamemnon chaos API                                         |
 | `NATS_URL`                 | No       | `nats://localhost:4222`    | NATS server used for JetStream tests                                        |
 | `CHAOS_RECOVERY_TIMEOUT_S` | No       | `10`                       | Seconds R03 waits for Agamemnon to come back after a `kill` fault          |
+| `CHAOS_AUDIT_LOG`          | No       | `stderr`                   | File path for the chaos injection audit trail (issue #44). `-`/`stderr`/unset emit to stderr; any other value is treated as a file path opened in append mode. |
+| `CHAOS_AUDIT_REQUESTER`    | No       | `$USER` or `unknown`       | Identity recorded in each audit record's `requester` field.                |
 
 Example:
 

--- a/cmake/SourcesAndHeaders.cmake
+++ b/cmake/SourcesAndHeaders.cmake
@@ -2,5 +2,6 @@ set(sources
     src/http_test_client.cpp)
 
 set(headers
+    include/projectcharybdis/chaos_audit.hpp
     include/projectcharybdis/http_test_client.hpp
     include/projectcharybdis/test_helpers.hpp)

--- a/include/projectcharybdis/chaos_audit.hpp
+++ b/include/projectcharybdis/chaos_audit.hpp
@@ -62,27 +62,33 @@ class ChaosAuditLog {
     // environment, so we treat it as tainted: only accept paths free of
     // embedded NULs and `..` traversal segments.
     if (dest_view.find('\0') != std::string_view::npos) {
-      std::cerr << R"({"chaos_audit_warning":"CHAOS_AUDIT_LOG contains embedded NUL; falling back to stderr"})"
-                << '\n';
+      std::cerr
+          << R"({"chaos_audit_warning":"CHAOS_AUDIT_LOG contains embedded NUL; falling back to stderr"})"
+          << '\n';
       return;
     }
     const std::filesystem::path candidate(dest_view);
     for (const auto& part : candidate) {
       if (part == "..") {
-        std::cerr << R"({"chaos_audit_warning":"CHAOS_AUDIT_LOG rejects parent-directory traversal; falling back to stderr"})"
-                  << '\n';
+        std::cerr
+            << R"({"chaos_audit_warning":"CHAOS_AUDIT_LOG rejects parent-directory traversal; falling back to stderr"})"
+            << '\n';
         return;
       }
     }
-    std::error_code ec;
-    const std::filesystem::path resolved = std::filesystem::weakly_canonical(candidate, ec);
-    const std::filesystem::path& open_path = ec ? candidate : resolved;
+    std::error_code err_code;
+    const std::filesystem::path resolved = std::filesystem::weakly_canonical(candidate, err_code);
+    const std::filesystem::path& open_path = err_code ? candidate : resolved;
     file_.open(open_path, std::ios::app);
     if (!file_.is_open()) {
-      std::cerr << R"({"chaos_audit_warning":"failed to open CHAOS_AUDIT_LOG=)" << open_path.string()
-                << R"(; falling back to stderr"})" << '\n';
+      std::cerr << R"({"chaos_audit_warning":"failed to open CHAOS_AUDIT_LOG=)"
+                << open_path.string() << R"(; falling back to stderr"})" << '\n';
     } else {
-      path_ = open_path.string();
+      // Preserve the caller-supplied destination string for the public
+      // accessor: callers reason about the path they passed via the
+      // environment, not the canonicalised form used internally to open
+      // the file.
+      path_ = std::string{dest_view};
     }
   }
 

--- a/include/projectcharybdis/chaos_audit.hpp
+++ b/include/projectcharybdis/chaos_audit.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <array>
 #include <chrono>
+#include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <ctime>
 #include <fstream>
@@ -51,8 +54,8 @@ class ChaosAuditLog {
         std::string_view{dest} != "stderr") {
       file_.open(dest, std::ios::app);
       if (!file_.is_open()) {
-        std::cerr << "{\"chaos_audit_warning\":\"failed to open CHAOS_AUDIT_LOG="
-                  << dest << "; falling back to stderr\"}\n";
+        std::cerr << R"({"chaos_audit_warning":"failed to open CHAOS_AUDIT_LOG=)" << dest
+                  << R"(; falling back to stderr"})" << '\n';
       } else {
         path_ = dest;
       }
@@ -74,9 +77,8 @@ class ChaosAuditLog {
 
   /// Log a fault removal attempt. `fault_id` is the id being removed (may be
   /// non-empty even when removal failed).
-  void log_remove(std::string_view fault_type, std::string_view fault_id,
-                  std::string_view target, int http_status,
-                  const nlohmann::json& response_body) {
+  void log_remove(std::string_view fault_type, std::string_view fault_id, std::string_view target,
+                  int http_status, const nlohmann::json& response_body) {
     emit_remove(fault_type, fault_id, target, http_status, response_body);
   }
 
@@ -89,19 +91,31 @@ class ChaosAuditLog {
     using clock = std::chrono::system_clock;
     const auto now = clock::now();
     const auto secs = std::chrono::time_point_cast<std::chrono::seconds>(now);
-    const auto millis =
-        std::chrono::duration_cast<std::chrono::milliseconds>(now - secs).count();
-    const std::time_t tt = clock::to_time_t(secs);
+    const auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(now - secs).count();
+    const std::time_t time_t_val = clock::to_time_t(secs);
     std::tm tm_buf{};
-    // NOLINTNEXTLINE(concurrency-mt-unsafe) — gmtime_r is the thread-safe form
-    gmtime_r(&tt, &tm_buf);
-    char buf[32] = {};
-    // YYYY-MM-DDTHH:MM:SS
-    std::strftime(static_cast<char*>(buf), sizeof(buf), "%Y-%m-%dT%H:%M:%S", &tm_buf);
-    char out[40] = {};
-    std::snprintf(static_cast<char*>(out), sizeof(out), "%s.%03lldZ",
-                  static_cast<const char*>(buf), static_cast<long long>(millis));
-    return std::string{static_cast<const char*>(out)};
+    // gmtime_r is the thread-safe form; available on POSIX targets we build for.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    gmtime_r(&time_t_val, &tm_buf);
+
+    // YYYY-MM-DDTHH:MM:SS is 19 chars; 24 leaves headroom for the NUL.
+    std::array<char, 24> date_buf{};
+    const std::size_t date_written =
+        std::strftime(date_buf.data(), date_buf.size(), "%Y-%m-%dT%H:%M:%S", &tm_buf);
+    if (date_written == 0) {
+      // strftime cannot encode this calendar value into the buffer; fall back
+      // to a well-formed sentinel so audit consumers can still parse the line.
+      return std::string{"1970-01-01T00:00:00.000Z"};
+    }
+
+    // ".NNNZ" is 5 chars; full ISO-8601 with millis fits in 24+5+1=30.
+    std::array<char, 32> out_buf{};
+    const int written = std::snprintf(out_buf.data(), out_buf.size(), "%s.%03lldZ", date_buf.data(),
+                                      static_cast<long long>(millis));
+    if (written <= 0 || static_cast<std::size_t>(written) >= out_buf.size()) {
+      return std::string{"1970-01-01T00:00:00.000Z"};
+    }
+    return std::string{out_buf.data(), static_cast<std::size_t>(written)};
   }
 
   static std::string current_requester() {
@@ -120,7 +134,7 @@ class ChaosAuditLog {
 
   void emit(std::string_view action, std::string_view fault_type, std::string_view target,
             int http_status, const nlohmann::json& response_body) {
-    nlohmann::json record = {
+    const nlohmann::json record = {
         {"schema_version", 1},
         {"timestamp", iso8601_utc_now()},
         {"action", std::string{action}},
@@ -134,10 +148,9 @@ class ChaosAuditLog {
     write_line(record);
   }
 
-  void emit_remove(std::string_view fault_type, std::string_view fault_id,
-                   std::string_view target, int http_status,
-                   const nlohmann::json& response_body) {
-    nlohmann::json record = {
+  void emit_remove(std::string_view fault_type, std::string_view fault_id, std::string_view target,
+                   int http_status, const nlohmann::json& response_body) {
+    const nlohmann::json record = {
         {"schema_version", 1},
         {"timestamp", iso8601_utc_now()},
         {"action", "remove"},

--- a/include/projectcharybdis/chaos_audit.hpp
+++ b/include/projectcharybdis/chaos_audit.hpp
@@ -1,0 +1,166 @@
+#pragma once
+
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <string_view>
+
+namespace projectcharybdis {
+
+/// Audit trail for chaos injection events.
+///
+/// Issue #44: chaos test outcomes are ephemeral. For a security/resilience
+/// audit trail this class emits a persistent JSON-lines record of every
+/// chaos fault injection and removal, capturing:
+///
+///   * timestamp     — ISO-8601 UTC with millisecond precision
+///   * action        — "inject" | "remove"
+///   * fault_type    — e.g. "network-partition", "latency", "kill", "queue-starve"
+///   * fault_id      — id returned by Agamemnon (empty for failed/unknown)
+///   * target        — Agamemnon base URL the fault was sent to
+///   * status        — HTTP status returned by Agamemnon (0 on transport failure)
+///   * requester     — `CHAOS_AUDIT_REQUESTER` env, or `USER`, or "unknown"
+///   * details       — verbatim Agamemnon response body (nlohmann::json)
+///
+/// Output destination is resolved on construction from the `CHAOS_AUDIT_LOG`
+/// environment variable:
+///   * unset / empty / "-" / "stderr"  -> std::cerr  (always available)
+///   * any other value                 -> appended to that file path
+///
+/// If the chosen file cannot be opened, the class falls back to std::cerr
+/// rather than crashing the test run, and emits a single warning line on
+/// std::cerr. There is no other I/O failure path: audit emission is
+/// best-effort telemetry; a chaos test must never be broken by a logging
+/// problem.
+///
+/// **Thread-safety:** all `log_*` methods serialize writes through an
+/// internal mutex, so a single `ChaosAuditLog` instance is safe to share
+/// across threads in the test process.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)
+class ChaosAuditLog {
+ public:
+  ChaosAuditLog() {
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    const char* dest = std::getenv("CHAOS_AUDIT_LOG");
+    if (dest != nullptr && *dest != '\0' && std::string_view{dest} != "-" &&
+        std::string_view{dest} != "stderr") {
+      file_.open(dest, std::ios::app);
+      if (!file_.is_open()) {
+        std::cerr << "{\"chaos_audit_warning\":\"failed to open CHAOS_AUDIT_LOG="
+                  << dest << "; falling back to stderr\"}\n";
+      } else {
+        path_ = dest;
+      }
+    }
+  }
+
+  ~ChaosAuditLog() {
+    if (file_.is_open()) {
+      file_.flush();
+      file_.close();
+    }
+  }
+
+  /// Log a fault injection attempt.
+  void log_inject(std::string_view fault_type, std::string_view target, int http_status,
+                  const nlohmann::json& response_body) {
+    emit("inject", fault_type, target, http_status, response_body);
+  }
+
+  /// Log a fault removal attempt. `fault_id` is the id being removed (may be
+  /// non-empty even when removal failed).
+  void log_remove(std::string_view fault_type, std::string_view fault_id,
+                  std::string_view target, int http_status,
+                  const nlohmann::json& response_body) {
+    emit_remove(fault_type, fault_id, target, http_status, response_body);
+  }
+
+  /// Test/diagnostic accessor: file path actually being written, or empty
+  /// string if events go to stderr.
+  [[nodiscard]] const std::string& path() const { return path_; }
+
+ private:
+  static std::string iso8601_utc_now() {
+    using clock = std::chrono::system_clock;
+    const auto now = clock::now();
+    const auto secs = std::chrono::time_point_cast<std::chrono::seconds>(now);
+    const auto millis =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now - secs).count();
+    const std::time_t tt = clock::to_time_t(secs);
+    std::tm tm_buf{};
+    // NOLINTNEXTLINE(concurrency-mt-unsafe) — gmtime_r is the thread-safe form
+    gmtime_r(&tt, &tm_buf);
+    char buf[32] = {};
+    // YYYY-MM-DDTHH:MM:SS
+    std::strftime(static_cast<char*>(buf), sizeof(buf), "%Y-%m-%dT%H:%M:%S", &tm_buf);
+    char out[40] = {};
+    std::snprintf(static_cast<char*>(out), sizeof(out), "%s.%03lldZ",
+                  static_cast<const char*>(buf), static_cast<long long>(millis));
+    return std::string{static_cast<const char*>(out)};
+  }
+
+  static std::string current_requester() {
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    const char* req = std::getenv("CHAOS_AUDIT_REQUESTER");
+    if (req != nullptr && *req != '\0') {
+      return std::string{req};
+    }
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    const char* user = std::getenv("USER");
+    if (user != nullptr && *user != '\0') {
+      return std::string{user};
+    }
+    return std::string{"unknown"};
+  }
+
+  void emit(std::string_view action, std::string_view fault_type, std::string_view target,
+            int http_status, const nlohmann::json& response_body) {
+    nlohmann::json record = {
+        {"schema_version", 1},
+        {"timestamp", iso8601_utc_now()},
+        {"action", std::string{action}},
+        {"fault_type", std::string{fault_type}},
+        {"fault_id", response_body.value("id", "")},
+        {"target", std::string{target}},
+        {"status", http_status},
+        {"requester", current_requester()},
+        {"details", response_body},
+    };
+    write_line(record);
+  }
+
+  void emit_remove(std::string_view fault_type, std::string_view fault_id,
+                   std::string_view target, int http_status,
+                   const nlohmann::json& response_body) {
+    nlohmann::json record = {
+        {"schema_version", 1},
+        {"timestamp", iso8601_utc_now()},
+        {"action", "remove"},
+        {"fault_type", std::string{fault_type}},
+        {"fault_id", std::string{fault_id}},
+        {"target", std::string{target}},
+        {"status", http_status},
+        {"requester", current_requester()},
+        {"details", response_body},
+    };
+    write_line(record);
+  }
+
+  void write_line(const nlohmann::json& record) {
+    const std::lock_guard<std::mutex> guard(mu_);
+    std::ostream& out = file_.is_open() ? static_cast<std::ostream&>(file_) : std::cerr;
+    out << record.dump() << '\n';
+    out.flush();
+  }
+
+  std::mutex mu_;
+  std::ofstream file_;
+  std::string path_;
+};
+
+}  // namespace projectcharybdis

--- a/include/projectcharybdis/chaos_audit.hpp
+++ b/include/projectcharybdis/chaos_audit.hpp
@@ -3,13 +3,14 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <ctime>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <mutex>
 #include <nlohmann/json.hpp>
+#include <sstream>
 #include <string>
 #include <string_view>
 
@@ -108,14 +109,13 @@ class ChaosAuditLog {
       return std::string{"1970-01-01T00:00:00.000Z"};
     }
 
-    // ".NNNZ" is 5 chars; full ISO-8601 with millis fits in 24+5+1=30.
-    std::array<char, 32> out_buf{};
-    const int written = std::snprintf(out_buf.data(), out_buf.size(), "%s.%03lldZ", date_buf.data(),
-                                      static_cast<long long>(millis));
-    if (written <= 0 || static_cast<std::size_t>(written) >= out_buf.size()) {
-      return std::string{"1970-01-01T00:00:00.000Z"};
-    }
-    return std::string{out_buf.data(), static_cast<std::size_t>(written)};
+    // Compose the trailing ".NNNZ" with std::ostringstream to avoid C-vararg
+    // snprintf (cppcoreguidelines-pro-type-vararg) while keeping the
+    // strftime-formatted date portion verbatim.
+    std::ostringstream out;
+    out << date_buf.data() << '.' << std::setw(3) << std::setfill('0')
+        << static_cast<std::int64_t>(millis) << 'Z';
+    return out.str();
   }
 
   static std::string current_requester() {

--- a/include/projectcharybdis/chaos_audit.hpp
+++ b/include/projectcharybdis/chaos_audit.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -51,15 +52,37 @@ class ChaosAuditLog {
   ChaosAuditLog() {
     // NOLINTNEXTLINE(concurrency-mt-unsafe)
     const char* dest = std::getenv("CHAOS_AUDIT_LOG");
-    if (dest != nullptr && *dest != '\0' && std::string_view{dest} != "-" &&
-        std::string_view{dest} != "stderr") {
-      file_.open(dest, std::ios::app);
-      if (!file_.is_open()) {
-        std::cerr << R"({"chaos_audit_warning":"failed to open CHAOS_AUDIT_LOG=)" << dest
-                  << R"(; falling back to stderr"})" << '\n';
-      } else {
-        path_ = dest;
+    if (dest == nullptr || *dest == '\0' || std::string_view{dest} == "-" ||
+        std::string_view{dest} == "stderr") {
+      return;
+    }
+    const std::string_view dest_view{dest};
+    // Reject path-traversal and other untrusted-input footguns before
+    // touching the filesystem. CHAOS_AUDIT_LOG flows in from the
+    // environment, so we treat it as tainted: only accept paths free of
+    // embedded NULs and `..` traversal segments.
+    if (dest_view.find('\0') != std::string_view::npos) {
+      std::cerr << R"({"chaos_audit_warning":"CHAOS_AUDIT_LOG contains embedded NUL; falling back to stderr"})"
+                << '\n';
+      return;
+    }
+    const std::filesystem::path candidate(dest_view);
+    for (const auto& part : candidate) {
+      if (part == "..") {
+        std::cerr << R"({"chaos_audit_warning":"CHAOS_AUDIT_LOG rejects parent-directory traversal; falling back to stderr"})"
+                  << '\n';
+        return;
       }
+    }
+    std::error_code ec;
+    const std::filesystem::path resolved = std::filesystem::weakly_canonical(candidate, ec);
+    const std::filesystem::path& open_path = ec ? candidate : resolved;
+    file_.open(open_path, std::ios::app);
+    if (!file_.is_open()) {
+      std::cerr << R"({"chaos_audit_warning":"failed to open CHAOS_AUDIT_LOG=)" << open_path.string()
+                << R"(; falling back to stderr"})" << '\n';
+    } else {
+      path_ = open_path.string();
     }
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,8 @@ find_package(nlohmann_json REQUIRED)
 add_executable(${PROJECT_NAME}_tests
     src/test_http_client_unit.cpp
     src/test_http_client_retry_unit.cpp
-    src/test_helpers_unit.cpp)
+    src/test_helpers_unit.cpp
+    src/test_chaos_audit_unit.cpp)
 
 target_compile_features(${PROJECT_NAME}_tests PRIVATE cxx_std_20)
 set_target_properties(${PROJECT_NAME}_tests PROPERTIES CXX_EXTENSIONS OFF)

--- a/test/src/test_chaos_api.cpp
+++ b/test/src/test_chaos_api.cpp
@@ -5,6 +5,7 @@
  * Requires: Agamemnon running at AGAMEMNON_URL (default http://localhost:8080)
  */
 
+#include "projectcharybdis/chaos_audit.hpp"
 #include "projectcharybdis/http_test_client.hpp"
 #include "projectcharybdis/test_helpers.hpp"
 
@@ -22,10 +23,26 @@ class ChaosApiTest : public ::testing::Test {
  protected:
   void SetUp() override {
     client_ = std::make_unique<HttpTestClient>(agamemnon_url());
+    audit_ = std::make_unique<ChaosAuditLog>();
     // NOLINTNEXTLINE(readability-implicit-bool-conversion)
     if (!client_->is_healthy()) {
       GTEST_SKIP() << "Agamemnon not reachable at " << agamemnon_url();
     }
+  }
+
+  // Issue #44: helpers that wrap the chaos verbs with audit emission so every
+  // injection event leaves a persistent record regardless of test outcome.
+  HttpTestClient::Response inject(const std::string& fault_type) {
+    auto response = client_->post("/v1/chaos/" + fault_type);
+    audit_->log_inject(fault_type, agamemnon_url(), response.status, response.body);
+    return response;
+  }
+
+  HttpTestClient::Response remove_fault(const std::string& fault_type,
+                                        const std::string& fault_id) {
+    auto response = client_->del("/v1/chaos/" + fault_id);
+    audit_->log_remove(fault_type, fault_id, agamemnon_url(), response.status, response.body);
+    return response;
   }
 
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -42,11 +59,13 @@ class ChaosApiTest : public ::testing::Test {
 
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
   std::unique_ptr<HttpTestClient> client_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
+  std::unique_ptr<ChaosAuditLog> audit_;
 };
 
 // E01: Inject network-partition fault
 TEST_F(ChaosApiTest, E01InjectNetworkPartition) {
-  auto [status, body] = client_->post("/v1/chaos/network-partition");
+  auto [status, body] = inject("network-partition");
   ASSERT_GE(status, 200);
   ASSERT_LT(status, 300);
   ASSERT_TRUE(body.contains("id"));
@@ -58,37 +77,37 @@ TEST_F(ChaosApiTest, E01InjectNetworkPartition) {
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)
   EXPECT_TRUE(fault_in_list(fault_id)) << "Fault not found in GET /v1/chaos";
 
-  std::ignore = client_->del("/v1/chaos/" + fault_id);
+  std::ignore = remove_fault("network-partition", fault_id);
 }
 
 // E02: Inject latency fault
 TEST_F(ChaosApiTest, E02InjectLatency) {
-  auto [status, body] = client_->post("/v1/chaos/latency");
+  auto [status, body] = inject("latency");
   ASSERT_GE(status, 200);
   ASSERT_LT(status, 300);
   EXPECT_EQ(body.value("type", ""), "latency");
 
-  std::ignore = client_->del("/v1/chaos/" + body.value("id", ""));
+  std::ignore = remove_fault("latency", body.value("id", ""));
 }
 
 // E03: Inject kill fault
 TEST_F(ChaosApiTest, E03InjectKill) {
-  auto [status, body] = client_->post("/v1/chaos/kill");
+  auto [status, body] = inject("kill");
   ASSERT_GE(status, 200);
   ASSERT_LT(status, 300);
   EXPECT_EQ(body.value("type", ""), "kill");
 
-  std::ignore = client_->del("/v1/chaos/" + body.value("id", ""));
+  std::ignore = remove_fault("kill", body.value("id", ""));
 }
 
 // E04: Remove fault
 TEST_F(ChaosApiTest, E04RemoveFault) {
-  auto [status, body] = client_->post("/v1/chaos/queue-starve");
+  auto [status, body] = inject("queue-starve");
   ASSERT_GE(status, 200);
   const std::string fault_id = body.value("id", "");
   ASSERT_FALSE(fault_id.empty());
 
-  auto [del_status, del_body] = client_->del("/v1/chaos/" + fault_id);
+  auto [del_status, del_body] = remove_fault("queue-starve", fault_id);
   EXPECT_GE(del_status, 200);
   EXPECT_LT(del_status, 300);
 

--- a/test/src/test_chaos_audit_unit.cpp
+++ b/test/src/test_chaos_audit_unit.cpp
@@ -30,10 +30,10 @@ namespace {
 class ChaosAuditLogTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    auto tmp = std::filesystem::temp_directory_path() /
-               ("charybdis-audit-" +
-                std::to_string(::testing::UnitTest::GetInstance()->random_seed()) + "-" +
-                ::testing::UnitTest::GetInstance()->current_test_info()->name() + ".jsonl");
+    auto tmp =
+        std::filesystem::temp_directory_path() /
+        ("charybdis-audit-" + std::to_string(::testing::UnitTest::GetInstance()->random_seed()) +
+         "-" + ::testing::UnitTest::GetInstance()->current_test_info()->name() + ".jsonl");
     path_ = tmp.string();
     // NOLINTNEXTLINE(concurrency-mt-unsafe)
     ::setenv("CHAOS_AUDIT_LOG", path_.c_str(), 1);
@@ -42,8 +42,8 @@ class ChaosAuditLogTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    std::error_code ec;
-    std::filesystem::remove(path_, ec);
+    std::error_code err_code;
+    std::filesystem::remove(path_, err_code);
     // NOLINTNEXTLINE(concurrency-mt-unsafe)
     ::unsetenv("CHAOS_AUDIT_LOG");
     // NOLINTNEXTLINE(concurrency-mt-unsafe)
@@ -51,10 +51,10 @@ class ChaosAuditLogTest : public ::testing::Test {
   }
 
   static std::string slurp(const std::string& path) {
-    std::ifstream in(path);
-    std::stringstream ss;
-    ss << in.rdbuf();
-    return ss.str();
+    std::ifstream input{path};
+    std::stringstream stream;
+    stream << input.rdbuf();
+    return stream.str();
   }
 
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
@@ -105,8 +105,8 @@ TEST_F(ChaosAuditLogTest, MultipleEventsAreNewlineDelimited) {
   }
   auto contents = slurp(path_);
   std::size_t lines = 0;
-  for (char c : contents) {
-    if (c == '\n') {
+  for (const char ch : contents) {
+    if (ch == '\n') {
       ++lines;
     }
   }

--- a/test/src/test_chaos_audit_unit.cpp
+++ b/test/src/test_chaos_audit_unit.cpp
@@ -1,0 +1,144 @@
+/**
+ * @file test_chaos_audit_unit.cpp
+ * @brief Unit tests for ChaosAuditLog (issue #44).
+ *
+ * Verifies:
+ *   * File-mode emission writes JSON-lines with the expected envelope.
+ *   * Each record carries timestamp, action, fault_type, fault_id, target,
+ *     status, requester, schema_version, details.
+ *   * Inject and remove actions are distinguishable.
+ *   * Unset / unwritable CHAOS_AUDIT_LOG falls back to stderr without
+ *     crashing the test process.
+ *
+ * No external services required; runs in the unit-test target.
+ */
+
+#include "projectcharybdis/chaos_audit.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace projectcharybdis {
+namespace {
+
+class ChaosAuditLogTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto tmp = std::filesystem::temp_directory_path() /
+               ("charybdis-audit-" +
+                std::to_string(::testing::UnitTest::GetInstance()->random_seed()) + "-" +
+                ::testing::UnitTest::GetInstance()->current_test_info()->name() + ".jsonl");
+    path_ = tmp.string();
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    ::setenv("CHAOS_AUDIT_LOG", path_.c_str(), 1);
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    ::setenv("CHAOS_AUDIT_REQUESTER", "unit-test", 1);
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove(path_, ec);
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    ::unsetenv("CHAOS_AUDIT_LOG");
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    ::unsetenv("CHAOS_AUDIT_REQUESTER");
+  }
+
+  static std::string slurp(const std::string& path) {
+    std::ifstream in(path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+  }
+
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
+  std::string path_;
+};
+
+TEST_F(ChaosAuditLogTest, InjectWritesEnvelopedJsonLine) {
+  const nlohmann::json body = {{"id", "f-123"}, {"type", "latency"}, {"active", true}};
+  {
+    ChaosAuditLog audit;
+    EXPECT_EQ(audit.path(), path_);
+    audit.log_inject("latency", "http://agamemnon:8080", 201, body);
+  }
+
+  auto contents = slurp(path_);
+  ASSERT_FALSE(contents.empty());
+  auto record = nlohmann::json::parse(contents);
+
+  EXPECT_EQ(record.value("schema_version", 0), 1);
+  EXPECT_EQ(record.value("action", ""), "inject");
+  EXPECT_EQ(record.value("fault_type", ""), "latency");
+  EXPECT_EQ(record.value("fault_id", ""), "f-123");
+  EXPECT_EQ(record.value("target", ""), "http://agamemnon:8080");
+  EXPECT_EQ(record.value("status", 0), 201);
+  EXPECT_EQ(record.value("requester", ""), "unit-test");
+  ASSERT_TRUE(record.contains("timestamp"));
+  EXPECT_FALSE(record.value("timestamp", "").empty());
+  ASSERT_TRUE(record.contains("details"));
+  EXPECT_EQ(record["details"], body);
+}
+
+TEST_F(ChaosAuditLogTest, RemoveActionIsDistinguishable) {
+  {
+    ChaosAuditLog audit;
+    audit.log_remove("kill", "f-9", "http://a:1", 204, nlohmann::json::object());
+  }
+  auto record = nlohmann::json::parse(slurp(path_));
+  EXPECT_EQ(record.value("action", ""), "remove");
+  EXPECT_EQ(record.value("fault_id", ""), "f-9");
+}
+
+TEST_F(ChaosAuditLogTest, MultipleEventsAreNewlineDelimited) {
+  {
+    ChaosAuditLog audit;
+    audit.log_inject("kill", "http://a", 201, nlohmann::json{{"id", "f-1"}});
+    audit.log_inject("latency", "http://a", 201, nlohmann::json{{"id", "f-2"}});
+    audit.log_remove("kill", "f-1", "http://a", 204, nlohmann::json::object());
+  }
+  auto contents = slurp(path_);
+  std::size_t lines = 0;
+  for (char c : contents) {
+    if (c == '\n') {
+      ++lines;
+    }
+  }
+  EXPECT_EQ(lines, 3U);
+}
+
+TEST(ChaosAuditLogStderr, FallsBackWhenEnvUnset) {
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::unsetenv("CHAOS_AUDIT_LOG");
+  ChaosAuditLog audit;
+  EXPECT_TRUE(audit.path().empty());
+  // Must not crash: writes to stderr.
+  audit.log_inject("kill", "http://a", 201, nlohmann::json{{"id", "f-x"}});
+}
+
+TEST(ChaosAuditLogStderr, FallsBackWhenEnvIsDash) {
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::setenv("CHAOS_AUDIT_LOG", "-", 1);
+  ChaosAuditLog audit;
+  EXPECT_TRUE(audit.path().empty());
+  audit.log_inject("kill", "http://a", 201, nlohmann::json{{"id", "f-y"}});
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::unsetenv("CHAOS_AUDIT_LOG");
+}
+
+TEST(ChaosAuditLogStderr, RequesterDefaultsWhenEnvUnset) {
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  ::unsetenv("CHAOS_AUDIT_REQUESTER");
+  // We cannot easily capture stderr here, but the call must not throw.
+  ChaosAuditLog audit;
+  audit.log_inject("kill", "http://a", 201, nlohmann::json{{"id", "f-z"}});
+}
+
+}  // namespace
+}  // namespace projectcharybdis

--- a/test/src/test_chaos_audit_unit.cpp
+++ b/test/src/test_chaos_audit_unit.cpp
@@ -51,7 +51,7 @@ class ChaosAuditLogTest : public ::testing::Test {
   }
 
   static std::string slurp(const std::string& path) {
-    std::ifstream input{path};
+    const std::ifstream input{path};
     std::stringstream stream;
     stream << input.rdbuf();
     return stream.str();
@@ -105,8 +105,8 @@ TEST_F(ChaosAuditLogTest, MultipleEventsAreNewlineDelimited) {
   }
   auto contents = slurp(path_);
   std::size_t lines = 0;
-  for (const char ch : contents) {
-    if (ch == '\n') {
+  for (const char chr : contents) {
+    if (chr == '\n') {
       ++lines;
     }
   }


### PR DESCRIPTION
## Summary

Closes #44. Adds `ChaosAuditLog`, a header-only structured JSON-lines audit trail that records every chaos fault injection and removal so chaos test outcomes are no longer ephemeral.

Each record captures:
- `timestamp` — ISO-8601 UTC with millisecond precision
- `action` — `inject` | `remove`
- `fault_type` — `network-partition`, `latency`, `kill`, `queue-starve`, ...
- `fault_id` — id returned by Agamemnon
- `target` — Agamemnon base URL the fault was sent to
- `status` — HTTP status returned by Agamemnon (0 on transport failure)
- `requester` — `CHAOS_AUDIT_REQUESTER` env, falling back to `$USER`, then `unknown`
- `details` — verbatim Agamemnon response body
- `schema_version` — `1`

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `CHAOS_AUDIT_LOG` | `stderr` | File path for the audit trail. `-`, `stderr`, or unset emit to stderr. Any other value is appended to that file path. |
| `CHAOS_AUDIT_REQUESTER` | `$USER` or `unknown` | Identity recorded in each record's `requester` field. |

If the requested file path cannot be opened the class falls back to stderr with a one-line warning rather than crashing the test process — audit emission is best-effort telemetry and must never break a chaos test. Writes are mutex-serialised, so one instance is safe across threads.

## Why a file-based JSONL log (not NATS)?

The issue body asks for persistence "to stderr or a dedicated file". A header-only JSONL emitter:
- Captures the audit gap immediately (timestamp + environment + fault) with zero new infrastructure.
- Plays nicely with the existing `hi.logs.>` Promtail pipeline by tailing the file (or capturing stderr from the test runner) — no nats.c FetchContent needed.
- Stays well inside the MEDIUM scope cap (6 files, ~340 LOC added).

A future ticket can layer NATS publishing on top by reusing the same envelope.

## Changes

- `include/projectcharybdis/chaos_audit.hpp` — new header-only `ChaosAuditLog`.
- `test/src/test_chaos_audit_unit.cpp` — 6 unit tests covering envelope shape, inject vs remove, multi-line ordering, and stderr-fallback paths.
- `test/src/test_chaos_api.cpp` — E01–E04 routed through `inject()` / `remove_fault()` helpers that emit audit records around every Agamemnon API call.
- `cmake/SourcesAndHeaders.cmake`, `test/CMakeLists.txt` — wire the new header and unit test into the build.
- `README.md` — documents `CHAOS_AUDIT_LOG` and `CHAOS_AUDIT_REQUESTER`.

## Test plan

- [x] Local build with conan + cmake (clang-tidy/cppcheck disabled locally due to pre-existing `stddef.h` toolchain issue on this host, unrelated to this PR — affects unchanged `src/http_test_client.cpp` on `main` too): `ProjectCharybdis_tests` and `ProjectCharybdis_integration_tests` both link clean.
- [x] All 6 new unit tests pass.
- [x] No regression in the 40 pre-existing unit tests (the one failing test, `HttpTestClientUnit.MalformedUrlFallsBackToDefaults`, fails on `main` too on hosts where something happens to listen on `localhost:8080`).
- [ ] CI: full `cmake --preset ci` build with `-Werror`, clang-tidy, cppcheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)